### PR TITLE
Delete Enable/Disable extension button

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ import { startListeners } from "./source/js/eventListeners.js";
 const extensionName = "SillyTavern-Stat-us-Maximus";
 const extensionFolderPath = `scripts/extensions/third-party/${extensionName}`;
 const defaultSettings = {
-    enabled: true,
     debug: false
 };
 
@@ -468,7 +467,6 @@ function settingsBooleanButton(event) {
 
 /**	Logs setting's values. */
 function displaySettings() {
-    console.debug("[" + extensionName + "]", `The extension is ${extensionSettings.enabled ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", `Debug mode is ${extensionSettings.debug ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", structuredClone(extensionSettings));
 }
@@ -480,7 +478,6 @@ async function loadHTMLSettings() {
     $("#extensions_settings2").append(settingsHtml);
 
     // Event Listeners for the extension HTML
-    $("#stat-us-max-activate-extension").on("input", settingsBooleanButton);
     $("#stat-us-max-activate-debug").on("input", settingsBooleanButton);
     $("#stat-us-max-check-configuration").on("click", displaySettings);
 
@@ -489,7 +486,6 @@ async function loadHTMLSettings() {
 
 /** Init setting values on the menu */
 function setSettings() {
-    $("#stat-us-max-activate-extension").prop("checked", extensionSettings.enabled).trigger("input");
     $("#stat-us-max-activate-debug").prop("checked", extensionSettings.debug).trigger("input");
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/settings.html
+++ b/settings.html
@@ -11,11 +11,6 @@ You might want to add additional HTML elements to ST. It's good practice to sepa
 
 			<div class="flex-container flex-column separator-bottom">
 				<b>Settings</b>
-
-				<label class="flex-container">
-					<input id="stat-us-max-activate-extension" stat-us-max-setting="enabled" type="checkbox" />
-					Enable/Disable the extension
-				</label>
 			</div>
 
 			<div class="flex-container flex-column">


### PR DESCRIPTION
## Changes
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/c7686fa23fbde6bb637485d32660b08b3aa2b003) - Delete Enable/Disable extension button - *It is a placeholder from the template, it does nothing.*