### PR TITLE
Allow to edit numbers inside entries from chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This extension adds a menu per character to have your notes, it is basically a s
 - [ ] Status block prefix/suffix in popup menus.
 - [ ] Custom depth buttons - dynamic depth if undefined.
 - [ ] Labels for input buttons in popup menus.
+- [ ] Status templates in the extension settings menu.
+- [ ] Turn entries into global entries.
 
 ## Installation
 Install the extension using this link: ```https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git```

--- a/index.js
+++ b/index.js
@@ -31,11 +31,6 @@ export const log = (...msg) => {
     console.log("[" + extensionName + "]", ...msg);
 };
 
-// SillyTavern.StatusTest = async () => {
-//     log(this_chid, characters[this_chid]);
-//     log(selected_group);
-// }
-
 // * Extension methods
 
 /** Destroys an element and all data associated with it
@@ -374,7 +369,7 @@ function addTracker(status, mesID, character) {
         statusTableBody.append(newRow);
 
         /* TODO
-            - [ ] Replace select button for an icon button
+            - [X] Replace select button for an icon button
             - [X] Highlight row on hover
             - [X] Hide description on disable
             - [X] Reduce font-size

--- a/index.js
+++ b/index.js
@@ -287,7 +287,28 @@ function addTracker(status, mesID, character) {
 
         el(newRow, '.status-title').textContent = entry.key;
         el(newRow, '.status-separator').innerHTML = entry.separator.replaceAll(/\n/g, "<br>");
-        el(newRow, '.status-description').textContent = entry.value;
+        el(newRow, '.status-description').innerHTML = "<span>" + entry.value.replaceAll(/\d+(\.\d+)?/g, (substring, p1, offset, string) => {
+            return `</span><input value="${substring}" type="number" class="text_pole w-auto m-0"><span>`;
+        }) + "</span>";
+
+        el(newRow, '.status-description').querySelectorAll('input[type="number"]').forEach(input => {
+            input.style.width = `calc(${String(input.value).length}ch + 3.5ch)`;
+
+            input.addEventListener("input", () => {
+                input.style.width = `calc(${String(input.value).length}ch + 3.5ch)`;
+
+                let newValue = "";
+
+                for (const child of el(newRow, '.status-description').children) {
+                    if (child instanceof HTMLSpanElement) newValue += child.textContent;
+                    if (child instanceof HTMLInputElement) newValue += child.value;
+                }
+
+                el(form, 'input[name="value"]').value = newValue;
+
+                form.dispatchEvent(evInput);
+            });
+        });
 
         for (const alt_val of entry.alt_values) {
             const option = document.createElement("div");

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ import { startListeners } from "./source/js/eventListeners.js";
 const extensionName = "SillyTavern-Stat-us-Maximus";
 const extensionFolderPath = `scripts/extensions/third-party/${extensionName}`;
 const defaultSettings = {
+    editNumbersFromChat: false,
     debug: false
 };
 
@@ -288,6 +289,7 @@ function addTracker(status, mesID, character) {
         el(newRow, '.status-title').textContent = entry.key;
         el(newRow, '.status-separator').innerHTML = entry.separator.replaceAll(/\n/g, "<br>");
         el(newRow, '.status-description').innerHTML = "<span>" + entry.value.replaceAll(/\d+(\.\d+)?/g, (substring, p1, offset, string) => {
+            if (!extensionSettings.editNumbersFromChat) return substring;
             return `</span><input value="${substring}" type="number" class="text_pole w-auto m-0"><span>`;
         }) + "</span>";
 
@@ -321,7 +323,10 @@ function addTracker(status, mesID, character) {
 
                 el(form, 'input[name="value"]').value = alt.value;
                 el(form, 'input[name="value_uid"]').value = alt.uid;
-                el(newRow, '.status-description').textContent = alt.value;
+                el(newRow, '.status-description').textContent = "<span>" + alt.value.replaceAll(/\d+(\.\d+)?/g, (substring, p1, offset, string) => {
+                    if (!extensionSettings.editNumbersFromChat) return substring;
+                    return `</span><input value="${substring}" type="number" class="text_pole w-auto m-0"><span>`;
+                }) + "</span>";
 
                 form.dispatchEvent(evInput);
             });
@@ -478,6 +483,11 @@ const settingsCallbacks = {
     /**	Triggers on enabled setting change. */
     enabled: () => {
         // Nothing by the moment
+    },
+
+    /**	Triggers on editNumbersFromChat setting change. */
+    editNumbersFromChat: () => {
+        fetchStatus({forceUIUpdate: true});
     }
 }
 
@@ -498,6 +508,7 @@ function settingsBooleanButton(event) {
 
 /**	Logs setting's values. */
 function displaySettings() {
+    console.debug("[" + extensionName + "]", `Edit numbers from chat is ${extensionSettings.editNumbersFromChat ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", `Debug mode is ${extensionSettings.debug ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", structuredClone(extensionSettings));
 }
@@ -509,6 +520,7 @@ async function loadHTMLSettings() {
     $("#extensions_settings2").append(settingsHtml);
 
     // Event Listeners for the extension HTML
+    $("#stat-us-max-activate-edit-numbers-from-chat").on("input", settingsBooleanButton);
     $("#stat-us-max-activate-debug").on("input", settingsBooleanButton);
     $("#stat-us-max-check-configuration").on("click", displaySettings);
 
@@ -517,6 +529,7 @@ async function loadHTMLSettings() {
 
 /** Init setting values on the menu */
 function setSettings() {
+    $("#stat-us-max-activate-edit-numbers-from-chat").prop("checked", extensionSettings.editNumbersFromChat);
     $("#stat-us-max-activate-debug").prop("checked", extensionSettings.debug).trigger("input");
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/settings.html
+++ b/settings.html
@@ -11,6 +11,11 @@ You might want to add additional HTML elements to ST. It's good practice to sepa
 
 			<div class="flex-container flex-column separator-bottom">
 				<b>Settings</b>
+
+				<label class="flex-container">
+					<input id="stat-us-max-activate-edit-numbers-from-chat" stat-us-max-setting="editNumbersFromChat" type="checkbox" />
+					Replaces numbers in your entries value with numeric inputs
+				</label>
 			</div>
 
 			<div class="flex-container flex-column">

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,4 +1,4 @@
-import { chat, event_types, eventSource } from "../../../../../../script.js";
+import { chat, event_types, eventSource, scrollChatToBottom } from "../../../../../../script.js";
 import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { selected_group } from "../../../../../group-chats.js";
 import { addGroupStatusButtons, fetchStatus, getActiveParticipants, getStatusDepth, log } from "../../index.js";
@@ -38,6 +38,7 @@ export function startListeners() {
         if (selected_group) addGroupStatusButtons();
 
         fetchStatus({forceUIUpdate: true});
+        scrollChatToBottom();
     });
 
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, async (...args) => {

--- a/style.css
+++ b/style.css
@@ -246,6 +246,10 @@
         max-width: 15%;
     }
 
+    .mw-min-content {
+        max-width: min-content;
+    }
+
     .mw-25 {
         max-width: 25%;
     }
@@ -373,5 +377,10 @@
 
     details[open] .status-value-uid-options {
         max-height: 15vh;
+    }
+
+    .status-description input.text_pole {
+        font-family: monospace;
+        border: unset;
     }
 }


### PR DESCRIPTION
## Changes
- [Update manifest.json](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/782ae794f1034e335a5a68e44caa9bfb6cec4699)
- [Update README.md](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/809940e8a20cd6c109867269483b519dd8868d6b)
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/67f57c10eae33c22ad467b98fa3fb418a17090ac) - Edit numbers inside entries from chat UI
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/d4731b1363690b563bbc02ef191f45867c0509e2) - Allow to disable edit numbers from chat
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/638a65980fadedcb7f7a250136ba1a23dd09e186) - Scroll chat to bottom after loading UI
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/3ebc642eeadf91d91c29d32e8a70ae516a0e9a62) - Clean code