### PR TITLE
Improve Popper performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,8 +232,6 @@ const onCallbacksClick = (e) => {
 
 document.getElementById("sheld").addEventListener('pointerdown', onCallbacksClick);
 
-SillyTavern.stumTest = () => log(callbacksClickValueUID);
-
 function showPopper(popperInstance, tooltip) {
     tooltip.setAttribute('data-show', '');
 

--- a/index.js
+++ b/index.js
@@ -232,32 +232,43 @@ const onCallbacksClick = (e) => {
 
 document.getElementById("sheld").addEventListener('pointerdown', onCallbacksClick);
 
-/** On scroll
-    @type {object[]}
-*/
-export let callbacksScrollValueUID = [];
+SillyTavern.stumTest = () => log(callbacksClickValueUID);
 
-const onCallbacksScroll = lodash.throttle(
-    (e) => {
-        const scrollTarget = $(e.target);
+function showPopper(popperInstance, tooltip) {
+    tooltip.setAttribute('data-show', '');
 
-        for (const obj of callbacksScrollValueUID) obj.callback(scrollTarget);
-    },
-    60,
-    {
-        leading: false,
-        trailing: true
-    }
-);
+    popperInstance.setOptions((options) => ({
+        ...options,
+        modifiers: [
+            ...options.modifiers
+        ]
+    }));
 
-document.getElementById("chat").addEventListener("scroll", onCallbacksScroll);
+    popperInstance.update();
+}
+
+function hidePopper(popperInstance, tooltip) {
+    tooltip.removeAttribute('data-show');
+
+    popperInstance.setOptions((options) => ({
+        ...options,
+        modifiers: [
+            ...options.modifiers
+        ]
+    }));
+}
 
 function addTracker(status, mesID, character) {
     const $chat = document.getElementById("chat");
     const entriesText = status.entries.reduce((acu, entry) => acu + entry.key + entry.value, "");
 
-    callbacksClickValueUID = callbacksClickValueUID.filter(obj => obj.target !== character.avatar);
-    callbacksScrollValueUID = callbacksScrollValueUID.filter(obj => obj.target !== character.avatar);
+    callbacksClickValueUID = callbacksClickValueUID.filter(obj => {
+        const result = obj.target !== character.avatar;
+
+        if (!result) obj.popper?.destroy();
+
+        return result;
+    });
 
     destroyElement(`.mes .stat-us-max-custom-css[avatar-target="${character.avatar}"]`);
     destroyElement(`.status-value-uid-options.list-group[avatar-target="${character.avatar}"]`);
@@ -496,16 +507,6 @@ function addTracker(status, mesID, character) {
             descriptionTarget = "alt_key";
         }
 
-        /**@type {HTMLSelectElement}*/
-        const selectValueUID = el(newRow, '.status-value-uid');
-        const optionsValueUID = document.createElement("div");
-        optionsValueUID.setAttribute("role", "tooltip");
-        optionsValueUID.setAttribute("avatar-target", character.avatar);
-        optionsValueUID.style.display = "none";
-        optionsValueUID.classList.add("status-value-uid-options", "list-group");
-
-        el(document, 'div[name="templatesAndPopupsWrapper"]').append(optionsValueUID);
-
         // Set Values
         el(form, 'input[name="enabled"]').value = entry.enabled;
         el(form, 'input[name="key"]').value = entry.key;
@@ -569,8 +570,6 @@ function addTracker(status, mesID, character) {
         updateDescription(entry.key, '.status-title', 'key');
         updateDescription(descriptionValue, '.status-description', descriptionTarget);
 
-        selectValueUID.value = String(entry.value_uid);
-
         // Add listeners
         form.addEventListener("submit", (e) => {
             e.preventDefault();
@@ -604,12 +603,36 @@ function addTracker(status, mesID, character) {
             el(newRow, '.hover-highlight').classList.toggle('disabled', !state);
         });
 
+        /**@type {HTMLSelectElement}*/
+        const selectValueUID = el(newRow, '.status-value-uid');
+
         if (entry.alt_values.length <= 1) toggleVisibility(selectValueUID, true);
         else {
             /** Only load swipes selector if there are more than one option */
+            const optionsValueUID = document.createElement("div");
+            optionsValueUID.setAttribute("role", "tooltip");
+            optionsValueUID.setAttribute("avatar-target", character.avatar);
+            optionsValueUID.classList.add("status-value-uid-options", "list-group");
 
-            const selectValueUIDPopper = Popper.createPopper(selectValueUID, optionsValueUID, {placement: "left"});
-            let isPopperOpen = false;
+            // el(document, 'div[name="templatesAndPopupsWrapper"]').append(optionsValueUID);
+            newRow.append(optionsValueUID);
+
+            selectValueUID.value = String(entry.value_uid);
+
+            const selectValueUIDPopper = Popper.createPopper(selectValueUID, optionsValueUID, {
+                modifiers: [{
+                    name: "computeStyles",
+                    options: {
+                        adaptive: false,
+                        gpuAcceleration: false,
+                        roundOffsets: false
+                    }
+                }, {
+                    name: "eventListeners",
+                    enabled: false
+                }],
+                placement: "left"
+            });
 
             for (const alt_val of entry.alt_values) {
                 const option = document.createElement("div");
@@ -617,15 +640,13 @@ function addTracker(status, mesID, character) {
                 option.innerText = (!alt_val.key ? null : alt_val.key) ?? ("UID " + alt_val.uid);
                 option.classList.add("list-group-item");
 
-                option.addEventListener("click", () => {
+                option.addEventListener("click", async () => {
                     const alt = getCharAltValue(character, entry.uid, option.getAttribute("value"));
 
                     el(form, 'input[name="value"]').value = alt.value;
                     el(form, 'input[name="value_uid"]').value = alt.uid;
 
-                    isPopperOpen = false;
-                    optionsValueUID.style.display = "none";
-                    selectValueUIDPopper.update();
+                    hidePopper(selectValueUIDPopper, optionsValueUID);
 
                     let formText = alt.value;
                     let formTarget = "value";
@@ -643,29 +664,21 @@ function addTracker(status, mesID, character) {
             }
 
             selectValueUID.addEventListener('click', function () {
-                isPopperOpen = !isPopperOpen;
-                optionsValueUID.style.display = isPopperOpen ? "block" : "none";
-                selectValueUIDPopper.update();
-            });
+                showPopper(selectValueUIDPopper, optionsValueUID);
 
-            callbacksClickValueUID.push({
-                target: character.avatar,
-                callback: async (clickTarget) => {
-                    if (
-                        isPopperOpen
-                        && !clickTarget.closest(`div[avatar-target="${character.avatar}"] select.status-value-uid`)
-                        && !clickTarget.closest(`.status-value-uid-options.list-group[avatar-target="${character.avatar}"]`)
-                    ) {
-                        isPopperOpen = false;
-                        optionsValueUID.style.display = "none";
-                        selectValueUIDPopper.update();
+                callbacksClickValueUID.push({
+                    target: character.avatar,
+                    popper: selectValueUIDPopper,
+                    callback: (clickTarget) => {
+                        if (
+                            !clickTarget.closest(`div[avatar-target="${character.avatar}"] select.status-value-uid`) &&
+                            !clickTarget.closest(`.status-value-uid-options.list-group[avatar-target="${character.avatar}"]`)
+                        ) {
+                            hidePopper(selectValueUIDPopper, optionsValueUID);
+                            callbacksClickValueUID = callbacksClickValueUID.filter(obj => obj.target !== character.avatar);
+                        }
                     }
-                }
-            });
-
-            callbacksScrollValueUID.push({
-                target: character.avatar,
-                callback: async (scrollTarget) => selectValueUIDPopper.update()
+                });
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -346,12 +346,6 @@ function addTracker(status, mesID, character) {
         el.classList.toggle("d-none", state);
     };
 
-    /** @param {HTMLElement} target */
-    const safeDispatch = (target, type = 'input', options = { bubbles: true, cancelable: true }) => {
-        const event = new Event(type, options);
-        target.dispatchEvent(event);
-    };
-
     statusTable.querySelector(".menu_button.fa-pen").addEventListener("click", async () => {
         const metadata = chat_metadata.stat_us_maximus;
 
@@ -621,13 +615,6 @@ function addTracker(status, mesID, character) {
 
             const selectValueUIDPopper = Popper.createPopper(selectValueUID, optionsValueUID, {
                 modifiers: [{
-                    name: "computeStyles",
-                    options: {
-                        adaptive: false,
-                        gpuAcceleration: false,
-                        roundOffsets: false
-                    }
-                }, {
                     name: "eventListeners",
                     enabled: false
                 }],

--- a/index.js
+++ b/index.js
@@ -630,6 +630,7 @@ function addTracker(status, mesID, character) {
                 option.addEventListener("click", async () => {
                     const alt = getCharAltValue(character, entry.uid, option.getAttribute("value"));
 
+                    el(form, 'input[name="alt_key"]').value = alt.key;
                     el(form, 'input[name="value"]').value = alt.value;
                     el(form, 'input[name="value_uid"]').value = alt.uid;
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,7 +1,7 @@
 import { chat, chat_metadata, event_types, eventSource, scrollChatToBottom } from "../../../../../../script.js";
 import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { selected_group } from "../../../../../group-chats.js";
-import { addGroupStatusButtons, callbacksClickValueUID, callbacksScrollValueUID, extensionSettings, fetchStatus, getActiveParticipants, getStatusDepth, log } from "../../index.js";
+import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatus, getActiveParticipants, getStatusDepth, log } from "../../index.js";
 import { createCharStatus, fillMissingMetadata, getCharStatus } from "./statusControls.js";
 
 /*
@@ -43,8 +43,7 @@ export function startListeners() {
         if (!chat_metadata.stat_us_maximus) chat_metadata.stat_us_maximus = [];
         if (selected_group) addGroupStatusButtons();
 
-        callbacksClickValueUID.splice(0);
-        callbacksScrollValueUID.splice(0);
+        callbacksClickValueUID.map(c => c.popper?.destroy()).splice(0);
 
         fillMissingMetadata();
         fetchStatus({forceUIUpdate: true});

--- a/style.css
+++ b/style.css
@@ -27,6 +27,11 @@ div[name="templatesAndPopupsWrapper"] {
     }
 
     .status-value-uid-options {
+        display: none;
+    }
+
+    .status-value-uid-options[data-show] {
+        display: block;
         z-index: 40;
         overflow-y: scroll;
         max-height: 15vh;
@@ -462,5 +467,20 @@ div[name="templatesAndPopupsWrapper"] {
 
     .input-label {
         display: var(--stum-input-label-display);
+    }
+    
+    .status-value-uid-options * {
+        border-radius: 0;
+    }
+
+    .status-value-uid-options {
+        display: none;
+    }
+
+    .status-value-uid-options[data-show] {
+        display: block;
+        z-index: 40;
+        overflow-y: scroll;
+        max-height: 15vh;
     }
 }


### PR DESCRIPTION
## Commits
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/6da9688d840212d83ebf08b6dff1d5593006ded3) - Improve Popper performance
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/70c2647e9e1440098d4883340810bff30db58eb4) - Re-enable non performance killers again
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/e2bfd8ea7ef6f67b8e9b8193a7eefc7b6ed28bf7) - Update alt_key hidden input on chat UI swipe
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/c992608d09ab2e0f08fa89a44775ab5640cf05d1) - Delete leftover test method
## Issue
> Popper's update method killed the tab performance on scroll, almost a rework of how is implemented had to be done.