### PR TITLE
Break object reference on status clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -506,7 +506,7 @@ function addTracker(status, mesID, character) {
         el(form, 'input[name="value"]').value = entry.value;
         el(form, 'input[name="value_uid"]').value = entry.value_uid;
 
-        el(newRow, '.status-separator').innerHTML = lodash.escape(entry.separator);
+        el(newRow, '.status-separator').innerHTML = lodash.escape(entry.separator).replaceAll(/\n/g, "<br>");
 
         const updateDescription = (text, el_target, form_target) => {
             destroyElement(el(newRow, el_target).children);
@@ -673,6 +673,9 @@ function addTracker(status, mesID, character) {
 
     /** Insert table in chat */
     const messText = $chat.querySelector(`.mes[mesid="${status.last_mes_id}"] .mes_text`);
+
+    if (!messText) return;
+
     messText.parentNode.insertBefore(statusTableContainer, messText);
     toggleVisibility(statusTableBody, status.is_collapsed ?? false);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -365,7 +365,8 @@ export function transferCharStatus(character, target, {deleteOriginal = false, o
             }
         };
 
-        const data = onlySendEntries ? {entries: originalStatus.entries} : originalStatus;
+        const originalStatusCloned = structuredClone(originalStatus);
+        const data = onlySendEntries ? {entries: originalStatusCloned.entries} : originalStatusCloned;
 
         for (const [key, value] of Object.entries(data)) {
             if (key === "avatar" || key === "depth" || key === "last_mes_id" || key === "is_user") continue;


### PR DESCRIPTION
## Commit
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/d1744ebe0345457e967b6ae85920a21a22f364db) - Break object reference on status clone
> This caused that when editing data in either the original or the clones stats, the data of all of them get overriden.