### PR TITLE
Improve chat inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const defaultSettings = {
 };
 
 const regexTextInput = /({{text)(::[^}\n]*)?(}})/g;
-const regexNumberInput = /({{number)(::[\d]+(\.[\d]+)?)?(}})/g;
+const regexNumberInput = /({{number)(::-?\d+\.?\d*)?(}})/g;
 const regexBooleanInput = /({{boolean)(::((false)|(true))::[^}\n]+::[^}\n]+)?(}})/g;
 const regexRangeInput = /({{range::)([\d]+(\.[\d]+)?)(::[\d]+(\.[\d]+)?){3}(}})/g;
 
@@ -214,7 +214,7 @@ function replaceSkip(str, search, replaceWith, targetIndex) {
 
     return str.replaceAll(search, match => {
         count++;
-        log (search, match, count, targetIndex, count === targetIndex);
+
         return count === targetIndex ? replaceWith : match;
     });
 }
@@ -256,6 +256,35 @@ function hidePopper(popperInstance, tooltip) {
     }));
 }
 
+function getCaretOffset(span, x, y) {
+    let offset = span.textContent.length;
+
+    if (document.caretPositionFromPoint) {
+        const pos = document.caretPositionFromPoint(x, y);
+        offset = pos.offset;
+    }
+    else if (document.caretRangeFromPoint) {
+        // For firef*x
+        const range = document.caretRangeFromPoint(x, y);
+        offset = range.startOffset;
+    }
+
+    return Math.min(offset, span.textContent.length);
+}
+
+function renderCaret(span, text, caretPos, selectEnd) {
+    const esc = s => lodash.escape(s);
+
+    if (caretPos < 0) return span.innerText = text;
+
+    const before = esc(text.slice(0, caretPos));
+    const selected = esc(text.slice(caretPos, selectEnd));
+    const after = esc(text.slice(selectEnd));
+
+    if (!selected) span.innerHTML = `${before}<span class="fake-caret"></span>${after}`;
+    else span.innerHTML = `${before}<span class="fake-selection">${selected}</span>${after}`;
+}
+
 function addTracker(status, mesID, character) {
     const $chat = document.getElementById("chat");
     const entriesText = status.entries.reduce((acu, entry) => acu + entry.key + entry.value, "");
@@ -293,7 +322,7 @@ function addTracker(status, mesID, character) {
                     <span class="status-separator"></span>
                     <span class="status-description d-contents"></span>
                 </p>
-                <button class="status-value-uid menu_button menu_button_icon fa-solid fa-list-1-2 m-0" aria-describedby="tooltip"></button>
+                <div class="status-value-uid fa-solid fa-bars-progress m-0" aria-describedby="tooltip"></div>
             </div>
         </td>
     `;
@@ -375,14 +404,22 @@ function addTracker(status, mesID, character) {
 
         newText = newText.replaceAll(regexTextInput, (match) => {
             const value = match.replaceAll(/(({{text(::)?)|(}}))/g, "");
-            const input = `<input type="text" value="${value}" class="text_pole m-0 chat-input-editor">`;
+            const input = `
+                <span class="fa-solid fa-t m-0 chat-input-icon select-none"></span>
+                <input type="text" value="${value}" class="type-text fake-input chat-input-editor" size="0">
+                <span class="text-quote select-none">${value}</span>
+            `;
 
             return input;
         });
 
         newText = newText.replaceAll(regexNumberInput, (match) => {
             const value = match.replaceAll(/(({{number(::)?)|(}}))/g, "");
-            const input = `<input type="number" value="${value === "" ? "0" : value}" class="text_pole m-0 chat-input-editor">`;
+            const input = `
+                <span class="fa-solid fa-n m-0 chat-input-icon select-none"></span>
+                <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0">
+                <span class="text-quote select-none">${value}</span>
+            `;
 
             return input;
         });
@@ -393,8 +430,8 @@ function addTracker(status, mesID, character) {
             const trueValue = props[1] ?? "true";
             const falseValue = props[2] ?? "false";
             const input = `
-                <input type="checkbox" ${checked === "true" ? "checked" : ""} data-true="${trueValue}" data-false="${falseValue}" class="m-0 chat-input-editor">
-                <span class="ignore"> ${checked === "true" ? trueValue : falseValue}</span>
+                <input type="checkbox" ${checked === "true" ? "checked" : ""} data-true="${trueValue}" data-false="${falseValue}" class="type-checkbox m-0 chat-input-editor">
+                <span class="text-quote select-none"> ${checked === "true" ? trueValue : falseValue}</span>
             `;
 
             return input;
@@ -407,7 +444,7 @@ function addTracker(status, mesID, character) {
             const step = props[2];
             const value = props[3];
             const input = `
-                <span class="d-flex flex-col flex-center gap-0 chat-input-editor ignore">
+                <span class="d-flex flex-col flex-center gap-0 type-range chat-input-editor">
                     <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-slider">
                     <input type="number" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-input">
                 </span>
@@ -446,14 +483,14 @@ function addTracker(status, mesID, character) {
             }
 
             if (chunk instanceof HTMLInputElement) {
-                if (chunk.type === "text") {
+                if (chunk.classList.contains("type-text")) {
                     const value = chunk.value;
                     index = ++countText;
                     match = regexTextInput;
                     newMacro = `{{text${value.length > 0 ? "::" : ""}${value}}}`;
                 }
 
-                if (chunk.type === "number") {
+                if (chunk.classList.contains("type-number")) {
                     const value = chunk.value;
                     index = ++countNumber;
                     match = regexNumberInput;
@@ -516,8 +553,9 @@ function addTracker(status, mesID, character) {
             if (!extensionSettings.editNumbersFromChat) return;
 
             el(newRow, el_target)
-            .querySelectorAll('input[type="text"]')
+            .querySelectorAll('input.type-text[type="text"]')
             .forEach((/**@type {HTMLInputElement}*/input) => {
+
                 input.onkeydown = (event) => {
                     if (/[{}\n]/.test(event.key)) event.preventDefault();
                 }
@@ -526,18 +564,73 @@ function addTracker(status, mesID, character) {
             el(newRow, el_target)
             .querySelectorAll('input.chat-input-editor')
             .forEach((/**@type {HTMLInputElement}*/input) => {
+                let lastValid = input.value;
+                let caretIndex;
+
                 if (input.type === "checkbox") {
                     input.nextElementSibling.textContent = " " + (input.checked ? input.dataset.true : input.dataset.false);
-                };
 
-                input.addEventListener("input", () => {
-                    if (input.type === "checkbox") {
+                    input.addEventListener("input", () => {
                         input.nextElementSibling.textContent = " " + (input.checked ? input.dataset.true : input.dataset.false);
-                    };
 
-                    el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
-                    form.dispatchEvent(inputEvent);
-                });
+                        el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
+                        form.dispatchEvent(inputEvent);
+                    });
+                } else {
+                    input.nextElementSibling.textContent = " " + (input.value ?? "");
+
+                    const evTargets = [input.nextElementSibling, input.previousElementSibling];
+
+                    function updateDisplay() {
+                        const pos = input.selectionStart;
+                        const finalPos = input.selectionEnd;
+                        renderCaret(input.nextElementSibling, lastValid, pos, finalPos);
+                    }
+
+                    evTargets.forEach((/**@type {HTMLSpanElement}*/span) => span.addEventListener("click", (e) => {
+                        e.preventDefault();
+                        const x = e.clientX, y = e.clientY;
+
+                        if (span.classList.contains("chat-input-icon")) caretIndex = input.value.length;
+                        else caretIndex = getCaretOffset(span, x, y);
+
+                        input.setSelectionRange(caretIndex, caretIndex);
+                        input.focus();
+                    }));
+
+                    input.addEventListener("input", () => {
+                        if (input.hasAttribute("pattern")) {
+                            const regex = new RegExp(input.getAttribute("pattern"));
+
+                            if (regex.test(input.value)) lastValid = input.value;
+                            else input.value = lastValid;
+                        } else lastValid = input.value;
+
+                        updateDisplay();
+
+                        el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
+                        form.dispatchEvent(inputEvent);
+                    });
+
+                    if (input.classList.contains("type-number")) {
+                        input.addEventListener('keydown', (e) => {
+                            if (isNaN(Number(input.value))) return setTimeout(() => input.dispatchEvent(inputEvent), 10);
+
+                            e.preventDefault();
+
+                            if (e.key === "ArrowUp") input.value = Number(input.value) + 1;
+                            if (e.key === "ArrowDown") input.value = Number(input.value) - 1;
+
+                            setTimeout(() => input.dispatchEvent(inputEvent), 10);
+                        });
+                    } else {
+                        input.addEventListener('keydown', () => setTimeout(updateDisplay, 10));
+                    }
+
+                    input.addEventListener('focus', updateDisplay);
+                    input.addEventListener('select', updateDisplay);
+                    input.addEventListener('blur', () => renderCaret(input.nextElementSibling, lastValid, -1));
+                }
             });
 
             el(newRow, el_target)
@@ -633,6 +726,7 @@ function addTracker(status, mesID, character) {
                     el(form, 'input[name="value_uid"]').value = alt.uid;
 
                     hidePopper(selectValueUIDPopper, optionsValueUID);
+                    callbacksClickValueUID = callbacksClickValueUID.filter(obj => obj.target !== character.avatar);
 
                     let formText = alt.value;
                     let formTarget = "value";
@@ -656,10 +750,7 @@ function addTracker(status, mesID, character) {
                     target: character.avatar,
                     popper: selectValueUIDPopper,
                     callback: (clickTarget) => {
-                        if (
-                            !clickTarget.closest(`div[avatar-target="${character.avatar}"] select.status-value-uid`) &&
-                            !clickTarget.closest(`.status-value-uid-options.list-group[avatar-target="${character.avatar}"]`)
-                        ) {
+                        if (!clickTarget.closest(`.status-value-uid-options.list-group[avatar-target="${character.avatar}"]`)) {
                             hidePopper(selectValueUIDPopper, optionsValueUID);
                             callbacksClickValueUID = callbacksClickValueUID.filter(obj => obj.target !== character.avatar);
                         }
@@ -886,7 +977,7 @@ async function loadHTMLSettings() {
 function setSettings() {
     $("#stat-us-max-auto-detect-participants").prop("checked", extensionSettings.autoDetectParticipants);
     $("#stat-us-max-edit-numbers-from-chat").prop("checked", extensionSettings.editNumbersFromChat);
-    $("#stat-us-max-hide-input-labels").prop("checked", extensionSettings.hideInputLabels);
+    $("#stat-us-max-hide-input-labels").prop("checked", extensionSettings.hideInputLabels).trigger("input");
     $("#stat-us-max-debug").prop("checked", extensionSettings.debug).trigger("input");
 }
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ export function destroyElement(element) {
     elem.find('*').each(function() {
         const child = $(this);
 
-        // Destroy even listeners
+        // Destroy event listeners
         child.off();
 
         // Clean jQuery custom library elements
@@ -448,7 +448,7 @@ function addTracker(status, mesID, character) {
             const falseValue = props[2] ?? "false";
             const input = `
                 <input type="checkbox" ${checked === "true" ? "checked" : ""} data-true="${trueValue}" data-false="${falseValue}" class="type-checkbox m-0 chat-input-editor">
-                <span class="text-quote select-none"> ${checked === "true" ? trueValue : falseValue}</span>
+                <span class="text-quote"> ${checked === "true" ? trueValue : falseValue}</span>
             `;
 
             return input;

--- a/index.js
+++ b/index.js
@@ -359,6 +359,10 @@ function addTracker(status, mesID, character) {
 
     const el = (target, class_name) => target.querySelector(class_name);
 
+    const dispatchInput = (/**@type {HTMLElement}*/target) => {
+        setTimeout(() => target.dispatchEvent(inputEvent), 10);
+    }
+
     /** @param {HTMLElement} el */
     const toggleSwitch = (el, callback = (param) => {}) => {
         // True if the final state is on
@@ -574,7 +578,7 @@ function addTracker(status, mesID, character) {
                         input.nextElementSibling.textContent = " " + (input.checked ? input.dataset.true : input.dataset.false);
 
                         el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
-                        form.dispatchEvent(inputEvent);
+                        dispatchInput(form);
                     });
                 } else {
                     input.nextElementSibling.textContent = " " + (input.value ?? "");
@@ -609,19 +613,18 @@ function addTracker(status, mesID, character) {
                         updateDisplay();
 
                         el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
-                        form.dispatchEvent(inputEvent);
+                        dispatchInput(form);
                     });
 
                     if (input.classList.contains("type-number")) {
                         input.addEventListener('keydown', (e) => {
-                            if (isNaN(Number(input.value))) return setTimeout(() => input.dispatchEvent(inputEvent), 10);
+                            if (!["ArrowUp", "ArrowDown"].includes(e.key)) return setTimeout(updateDisplay, 10);
 
                             e.preventDefault();
 
-                            if (e.key === "ArrowUp") input.value = Number(input.value) + 1;
-                            if (e.key === "ArrowDown") input.value = Number(input.value) - 1;
+                            input.value = String(Number(input.value) + ((e.key === "ArrowUp") ? 1 : -1));
 
-                            setTimeout(() => input.dispatchEvent(inputEvent), 10);
+                            dispatchInput(input);
                         });
                     } else {
                         input.addEventListener('keydown', () => setTimeout(updateDisplay, 10));
@@ -647,7 +650,7 @@ function addTracker(status, mesID, character) {
                     inputRange.value = original.value;
 
                     el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
-                    form.dispatchEvent(inputEvent);
+                    dispatchInput(form);
                 });
             });
         }
@@ -667,7 +670,7 @@ function addTracker(status, mesID, character) {
         form.addEventListener("input", () => {
             clearTimeout(formDebounceTimer);
 
-            formDebounceTimer = window.setTimeout(() => form.requestSubmit(), DEBOUNCE_MS);
+            formDebounceTimer = setTimeout(() => form.requestSubmit(), DEBOUNCE_MS);
         });
 
         killSwitch.addEventListener("click", (e) => {
@@ -678,7 +681,7 @@ function addTracker(status, mesID, character) {
                 el(newRow, '.hover-highlight').classList.toggle('disabled', !state);
             });
 
-            form.dispatchEvent(inputEvent);
+            dispatchInput(form);
         });
 
         // Set up UI
@@ -737,7 +740,7 @@ function addTracker(status, mesID, character) {
                     }
 
                     updateDescription(formText, '.status-description', formTarget);
-                    form.dispatchEvent(inputEvent);
+                    dispatchInput(form);
                 });
 
                 optionsValueUID.append(option);

--- a/index.js
+++ b/index.js
@@ -256,29 +256,13 @@ function hidePopper(popperInstance, tooltip) {
     }));
 }
 
-function getCaretOffset(span, x, y) {
-    let offset = span.textContent.length;
-
-    if (document.caretPositionFromPoint) {
-        const pos = document.caretPositionFromPoint(x, y);
-        offset = pos.offset;
-    }
-    else if (document.caretRangeFromPoint) {
-        // For firef*x
-        const range = document.caretRangeFromPoint(x, y);
-        offset = range.startOffset;
-    }
-
-    return Math.min(offset, span.textContent.length);
-}
-
 function renderCaret(span, text, caretPos, selectEnd = caretPos) {
     const esc = s => lodash.escape(s);
 
-    if (caretPos < 0) return span.innerText = text;
+    if (caretPos < 0) return span.textContent = text;
 
     const before = esc(text.slice(0, caretPos));
-    const selected = esc(text.slice(caretPos, selectEnd));
+    const selected = caretPos !== selectEnd ? esc(text.slice(caretPos, selectEnd)) : false;
     const after = esc(text.slice(selectEnd));
 
     if (!selected) span.innerHTML = `${before}<span class="fake-caret"></span>${after}`;
@@ -286,9 +270,32 @@ function renderCaret(span, text, caretPos, selectEnd = caretPos) {
 }
 
 function updateCaretDisplay(input, lastInputValue) {
-    const pos = input.selectionStart;
-    const finalPos = input.selectionEnd;
-    renderCaret(input.nextElementSibling, lastInputValue, pos, finalPos);
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+    renderCaret(input.nextElementSibling, lastInputValue, start, end);
+}
+
+/**
+    @param {HTMLElement} elem
+    @returns {object}
+*/
+function getSelectedTextInElem(elem) {
+    const selection = window.getSelection();
+
+    if (!selection?.rangeCount) return {start: -1, end: -1};
+
+    const range = selection.getRangeAt(0);
+
+    if (elem.contains(range.startContainer) && elem.contains(range.endContainer))
+        return {start: range.startOffset, end: range.endOffset};
+
+    else if (elem.contains(range.startContainer))
+        return {start: range.startOffset, end: elem.textContent.length};
+
+    else if (elem.contains(range.endContainer))
+        return {start: 0, end: range.endOffset};
+
+    else return {start: -1, end: -1};
 }
 
 function addTracker(status, mesID, character) {
@@ -416,8 +423,8 @@ function addTracker(status, mesID, character) {
             const value = match.replaceAll(/(({{text(::)?)|(}}))/g, "");
             const input = `
                 <span class="fa-solid fa-t m-0 chat-input-icon select-none"></span>
-                <input type="text" value="${value}" class="type-text fake-input chat-input-editor" size="0">
-                <span class="text-quote select-none">${value}</span>
+                <input type="text" value="${value}" class="type-text fake-input chat-input-editor" autocomplete="off" size="0">
+                <span class="text-quote">${value}</span>
             `;
 
             return input;
@@ -428,7 +435,7 @@ function addTracker(status, mesID, character) {
             const input = `
                 <span class="fa-solid fa-n m-0 chat-input-icon select-none"></span>
                 <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0">
-                <span class="text-quote select-none">${value}</span>
+                <span class="text-quote">${value}</span>
             `;
 
             return input;
@@ -574,8 +581,6 @@ function addTracker(status, mesID, character) {
             el(newRow, el_target)
             .querySelectorAll('input.chat-input-editor')
             .forEach((/**@type {HTMLInputElement}*/input) => {
-                let lastValid = input.value;
-                let caretIndex;
 
                 if (input.type === "checkbox") {
                     input.nextElementSibling.textContent = " " + (input.checked ? input.dataset.true : input.dataset.false);
@@ -587,20 +592,33 @@ function addTracker(status, mesID, character) {
                         dispatchInput(form);
                     });
                 } else {
+                    const eventTargets = [input.nextElementSibling, input.previousElementSibling];
+                    let lastValid = input.value;
+
                     input.nextElementSibling.textContent = " " + (input.value ?? "");
 
-                    const eventTargets = [input.nextElementSibling, input.previousElementSibling];
+                    eventTargets.forEach((/**@type {HTMLSpanElement}*/span) => {
+                        let spanSelected = false;
 
-                    eventTargets.forEach((/**@type {HTMLSpanElement}*/span) => span.addEventListener("click", (e) => {
-                        e.preventDefault();
-                        const x = e.clientX, y = e.clientY;
+                        span.addEventListener("pointerdown", (e) => {
+                            if (spanSelected) return;
 
-                        if (span.classList.contains("chat-input-icon")) caretIndex = input.value.length;
-                        else caretIndex = getCaretOffset(span, x, y);
+                            spanSelected = true;
+                        });
 
-                        input.setSelectionRange(caretIndex, caretIndex);
-                        input.focus();
-                    }));
+                        document.addEventListener("click", (e) => {
+                            if (!spanSelected) return;
+
+                            spanSelected = false;
+                            let selection;
+
+                            if (span.classList.contains("chat-input-icon")) selection = {start: input.value.length, end: input.value.length};
+                            else selection = getSelectedTextInElem(span);
+
+                            input.setSelectionRange(selection.start, selection.end);
+                            input.focus();
+                        });
+                    });
 
                     input.addEventListener("input", () => {
                         if (input.hasAttribute("pattern")) {
@@ -610,14 +628,12 @@ function addTracker(status, mesID, character) {
                             else input.value = lastValid;
                         } else lastValid = input.value;
 
-                        updateCaretDisplay(input, lastValid);
-
                         el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
                         dispatchInput(form);
                     });
 
                     if (input.classList.contains("type-number")) {
-                        input.addEventListener('keydown', (e) => {
+                        input.addEventListener("keydown", (e) => {
                             if (!["ArrowUp", "ArrowDown"].includes(e.key)) return setTimeout(() => updateCaretDisplay(input, lastValid), 10);
 
                             e.preventDefault();
@@ -625,14 +641,14 @@ function addTracker(status, mesID, character) {
                             input.value = String(Number(input.value) + ((e.key === "ArrowUp") ? 1 : -1));
 
                             dispatchInput(input);
+                            setTimeout(() => updateCaretDisplay(input, lastValid), 10);
                         });
                     } else {
-                        input.addEventListener('keydown', () => setTimeout(() => updateCaretDisplay(input, lastValid), 10));
+                        input.addEventListener("keydown", () => setTimeout(() => updateCaretDisplay(input, lastValid), 10));
                     }
 
-                    input.addEventListener('focus', () => updateCaretDisplay(input, lastValid));
-                    input.addEventListener('select', () => updateCaretDisplay(input, lastValid));
-                    input.addEventListener('blur', () => renderCaret(input.nextElementSibling, lastValid, -1));
+                    input.addEventListener("focus", () => updateCaretDisplay(input, lastValid));
+                    input.addEventListener("blur", () => renderCaret(input.nextElementSibling, lastValid, -1));
                 }
             });
 
@@ -718,7 +734,7 @@ function addTracker(status, mesID, character) {
             for (const alt_val of entry.alt_values) {
                 const option = document.createElement("div");
                 option.setAttribute("value", String(alt_val.uid));
-                option.innerText = (!alt_val.key ? null : alt_val.key) ?? ("UID " + alt_val.uid);
+                option.textContent = (!alt_val.key ? null : alt_val.key) ?? ("UID " + alt_val.uid);
                 option.classList.add("list-group-item");
 
                 option.addEventListener("click", async () => {

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ const defaultSettings = {
     editNumbersFromChat: false,
     autoDetectParticipants: true,
     hideInputLabels: false,
+    rangeInputWidth: "auto",
     debug: false
 };
 
@@ -939,6 +940,8 @@ export function addGroupStatusButtons() {
 // * Methods in charge of controlling the extension settings
 
 const settingsCallbacks = {
+    rangeInputWidthTimeout: undefined,
+
     /**	Triggers on editNumbersFromChat change. */
     editNumbersFromChat: () => {
         fetchStatus({forceUIUpdate: true});
@@ -949,13 +952,39 @@ const settingsCallbacks = {
         const newDisplay = extensionSettings.hideInputLabels ? 'none' : 'block';
 
         document.documentElement.style.setProperty('--stum-input-label-display', newDisplay);
+    },
+
+    /**	Triggers on rangeInputWidth change. */
+    rangeInputWidth: () => {
+        clearTimeout(settingsCallbacks.rangeInputWidthTimeout);
+
+        const newWidth = String($("#stat-us-max-range-input-width").val());
+
+        settingsCallbacks.rangeInputWidthTimeout = setTimeout(() =>
+            document.documentElement.style.setProperty('--stum-range-input-width', newWidth), 100
+        );
     }
 }
 
-/** Changes a setting value and triggers a callback if there's any on settingsCallbacks. */
+/** Changes a boolean setting value and triggers a callback if there's any on settingsCallbacks. */
 function settingsBooleanButton(event) {
     const target = event.target;
     const value = Boolean($(target).prop("checked"));
+    const setting = target.getAttribute("stat-us-max-setting");
+    const callback = settingsCallbacks[setting];
+
+    extensionSettings[setting] = value;
+
+    if (callback) callback();
+
+    log("toggleSetting " + setting, value);
+    saveSettingsDebounced();
+}
+
+/** Changes a string setting value and triggers a callback if there's any on settingsCallbacks. */
+function settingsTextButton(event) {
+    const target = event.target;
+    const value = String($(target).val());
     const setting = target.getAttribute("stat-us-max-setting");
     const callback = settingsCallbacks[setting];
 
@@ -986,6 +1015,7 @@ async function loadHTMLSettings() {
     $("#stat-us-max-auto-detect-participants").on("input", settingsBooleanButton);
     $("#stat-us-max-edit-numbers-from-chat").on("input", settingsBooleanButton);
     $("#stat-us-max-hide-input-labels").on("input", settingsBooleanButton);
+    $("#stat-us-max-range-input-width").on("input", settingsTextButton);
     $("#stat-us-max-debug").on("input", settingsBooleanButton);
     $("#stat-us-max-check-configuration").on("click", displaySettings);
 
@@ -997,6 +1027,7 @@ function setSettings() {
     $("#stat-us-max-auto-detect-participants").prop("checked", extensionSettings.autoDetectParticipants);
     $("#stat-us-max-edit-numbers-from-chat").prop("checked", extensionSettings.editNumbersFromChat);
     $("#stat-us-max-hide-input-labels").prop("checked", extensionSettings.hideInputLabels).trigger("input");
+    $("#stat-us-max-range-input-width").val(extensionSettings.rangeInputWidth).trigger("input");
     $("#stat-us-max-debug").prop("checked", extensionSettings.debug).trigger("input");
 }
 

--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ function getCaretOffset(span, x, y) {
     return Math.min(offset, span.textContent.length);
 }
 
-function renderCaret(span, text, caretPos, selectEnd) {
+function renderCaret(span, text, caretPos, selectEnd = caretPos) {
     const esc = s => lodash.escape(s);
 
     if (caretPos < 0) return span.innerText = text;
@@ -283,6 +283,12 @@ function renderCaret(span, text, caretPos, selectEnd) {
 
     if (!selected) span.innerHTML = `${before}<span class="fake-caret"></span>${after}`;
     else span.innerHTML = `${before}<span class="fake-selection">${selected}</span>${after}`;
+}
+
+function updateCaretDisplay(input, lastInputValue) {
+    const pos = input.selectionStart;
+    const finalPos = input.selectionEnd;
+    renderCaret(input.nextElementSibling, lastInputValue, pos, finalPos);
 }
 
 function addTracker(status, mesID, character) {
@@ -583,15 +589,9 @@ function addTracker(status, mesID, character) {
                 } else {
                     input.nextElementSibling.textContent = " " + (input.value ?? "");
 
-                    const evTargets = [input.nextElementSibling, input.previousElementSibling];
+                    const eventTargets = [input.nextElementSibling, input.previousElementSibling];
 
-                    function updateDisplay() {
-                        const pos = input.selectionStart;
-                        const finalPos = input.selectionEnd;
-                        renderCaret(input.nextElementSibling, lastValid, pos, finalPos);
-                    }
-
-                    evTargets.forEach((/**@type {HTMLSpanElement}*/span) => span.addEventListener("click", (e) => {
+                    eventTargets.forEach((/**@type {HTMLSpanElement}*/span) => span.addEventListener("click", (e) => {
                         e.preventDefault();
                         const x = e.clientX, y = e.clientY;
 
@@ -610,7 +610,7 @@ function addTracker(status, mesID, character) {
                             else input.value = lastValid;
                         } else lastValid = input.value;
 
-                        updateDisplay();
+                        updateCaretDisplay(input, lastValid);
 
                         el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
                         dispatchInput(form);
@@ -618,7 +618,7 @@ function addTracker(status, mesID, character) {
 
                     if (input.classList.contains("type-number")) {
                         input.addEventListener('keydown', (e) => {
-                            if (!["ArrowUp", "ArrowDown"].includes(e.key)) return setTimeout(updateDisplay, 10);
+                            if (!["ArrowUp", "ArrowDown"].includes(e.key)) return setTimeout(() => updateCaretDisplay(input, lastValid), 10);
 
                             e.preventDefault();
 
@@ -627,11 +627,11 @@ function addTracker(status, mesID, character) {
                             dispatchInput(input);
                         });
                     } else {
-                        input.addEventListener('keydown', () => setTimeout(updateDisplay, 10));
+                        input.addEventListener('keydown', () => setTimeout(() => updateCaretDisplay(input, lastValid), 10));
                     }
 
-                    input.addEventListener('focus', updateDisplay);
-                    input.addEventListener('select', updateDisplay);
+                    input.addEventListener('focus', () => updateCaretDisplay(input, lastValid));
+                    input.addEventListener('select', () => updateCaretDisplay(input, lastValid));
                     input.addEventListener('blur', () => renderCaret(input.nextElementSibling, lastValid, -1));
                 }
             });

--- a/settings.html
+++ b/settings.html
@@ -27,6 +27,11 @@ You might want to add additional HTML elements to ST. It's good practice to sepa
 					Hide input labels in the popup menu
 				</label>
 
+				<label class="d-flex flex-col flex-start-center gap-5px">
+                    <small class="text-quote">Set the CSS size of range inputs in the chat</small>
+					<input id="stat-us-max-range-input-width" stat-us-max-setting="rangeInputWidth" type="text" pattern="[^\s]" class="text_pole textarea_compact m-0" />
+				</label>
+
 				<div class="flex-container w-100">
 					<a id="stat-us-max-check-docs" title="Link to the repository" class="menu_button w-100" type="button" target="_blank" href="https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus?tab=readme-ov-file#features">
                         Open the docs

--- a/style.css
+++ b/style.css
@@ -68,6 +68,12 @@ div[name="templatesAndPopupsWrapper"] {
     }
 }
 
+@keyframes stumcaretblink {
+    0% { opacity: 1; }
+    50% { opacity: 0; }
+    100% { opacity: 1; }
+}
+
 .popup:has(.stat-us-max-popup) {
     background-color: var(--SmartThemeBotMesBlurTintColor);
     border-color: var(--stat-us-border-color) !important;
@@ -490,13 +496,10 @@ div[name="templatesAndPopupsWrapper"] {
     .fake-caret {
         display: inline-block;
         width: 3px;
-        background-color: var(--SmartThemeBodyColor);
-        animation: blink 1s step-end infinite;
         height: 1em;
-    }
-
-    @keyframes blink {
-        50% { opacity: 0; }
+        background-color: var(--SmartThemeBodyColor);
+        animation: stumcaretblink 1s steps(1) infinite;
+        opacity: 1;
     }
 
     span.chat-input-editor {

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 :root {
     --stum-input-label-display: block;
+    --stum-range-input-width: auto;
 }
 
 #stat-us-max-settings-window div.flex-container.flex-column,
@@ -237,6 +238,11 @@ div[name="templatesAndPopupsWrapper"] {
     .flex-center-start {
         justify-content: flex-start;
         align-items: center;
+    }
+
+    .flex-start-center {
+        justify-content: center;
+        align-items: flex-start;
     }
 
     .flex-end-start {
@@ -496,7 +502,9 @@ div[name="templatesAndPopupsWrapper"] {
     span.chat-input-editor {
         display: inline-flex;
         vertical-align: middle;
-        min-width: 8ch;
+        min-width: 5ch;
+        width: var(--stum-range-input-width);
+        max-width: unset;
 
         input[type="range"] {
             margin-top: 5px !important;

--- a/style.css
+++ b/style.css
@@ -196,6 +196,10 @@ div[name="templatesAndPopupsWrapper"] {
         text-align: center;
     }
 
+    .text-quote {
+        color: var(--SmartThemeQuoteColor);
+    }
+
     .separator-x {
         border-bottom: 1px solid;
         border-color: var(--stat-us-border-color) !important;
@@ -374,15 +378,18 @@ div[name="templatesAndPopupsWrapper"] {
         color: currentColor;
     }
 
-    .kill-switch.fa-toggle-on {
+    .kill-switch.fa-toggle-on,
+    .status-value-uid {
         color: var(--SmartThemeQuoteColor);
     }
 
-    .kill-switch {
+    .kill-switch,
+    .status-value-uid {
         font-size: x-large;
     }
 
-    .kill-switch:hover {
+    .kill-switch:hover,
+    .status-value-uid:hover {
         cursor: pointer;
     }
 
@@ -449,6 +456,43 @@ div[name="templatesAndPopupsWrapper"] {
         min-width: 5ch;
     }
 
+    .chat-input-icon {
+        font-weight: bolder;
+        vertical-align: baseline;
+    }
+
+    .select-none {
+        user-select: none;
+        -webkit-user-select: none;
+    }
+
+    .fake-input {
+        position: absolute;
+        inset: 0;
+        width: 0;
+        height: 0;
+        opacity: 0;
+        border: none;
+        background: transparent;
+    }
+
+    .fake-selection {
+        background-color: var(--SmartThemeBodyColor);
+        color: var(--SmartThemeBlurTintColor);
+    }
+
+    .fake-caret {
+        display: inline-block;
+        width: 3px;
+        background-color: var(--SmartThemeBodyColor);
+        animation: blink 1s step-end infinite;
+        height: 1em;
+    }
+
+    @keyframes blink {
+        50% { opacity: 0; }
+    }
+
     span.chat-input-editor {
         display: inline-flex;
         vertical-align: middle;
@@ -468,7 +512,7 @@ div[name="templatesAndPopupsWrapper"] {
     .input-label {
         display: var(--stum-input-label-display);
     }
-    
+
     .status-value-uid-options * {
         border-radius: 0;
     }


### PR DESCRIPTION
## Commits
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/38c585a08dd8b09f2bf391fe099415dfa5664b0c) - Create fake chat inputs
> These inputs allow to type whitout any worry for text overflow.
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/95f4078403705188a4e9263811bd361ebdf7e60a) - Prevent event clash on dispatch
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/bb99fa75ec206b47129ed86465f590b6e96fb535) - Let's try not to reach stack overflow
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/91c6696243605f7cef845f8c7b92e3c8ea4693e7) - Detect pointer selection on chat inputs
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/24f7664a76014ece275baaac172e041874bf326c) - Allow to select boolean tooltips
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/26/commits/3f5531b4c19da047f77d3c1d11eef2fe3119f5be) - Add input range custom width from the settings
- [Styles](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/26/commits/253295c45d3a3057657a1e8005ca5a2122b98df4) - Add blink animation to input caret
## Planned - Issue #25
- [x] Get rid of built-in inputs and add *fake* inputs - this should allow the user to type without having to worry about the text overflowing the box
- [x] The input has to blend with the rest of the text
- [x] Add a button to interact with the input when it is empty
### Fake input
- [x] Be able to be edited from the click point
- [x] Be able to select text from the input with keys
- [x] Be able to select text from the input with pointer
- [x] Display the text selection
- [x] Display the position of the caret
### Numeric input
- [x] Increase/descrease with arrows
### Range input
- [x] Setting to set a global size