### PR TITLE
Status shortcuts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1176,9 +1176,7 @@ function initButtons() {
     });
 
     const groupChatsBlock = document.getElementById("rm_group_chats_block");
-    groupChatsBlock
-        .querySelector('.inline-drawer')
-        .after(hr.cloneNode(), groupStatusContainer, hr.cloneNode());
+    groupChatsBlock.querySelector('.inline-drawer').after(groupStatusContainer);
 }
 
 (async function initExtension() {

--- a/index.js
+++ b/index.js
@@ -1084,7 +1084,7 @@ function initButtons() {
         const users = [];
 
         for (const status of metadata) {
-            const user = getParticipant(status.avatar, status.is_user);
+            const user = getUser(status.avatar);
 
             if (user) users.push(user);
         }
@@ -1131,6 +1131,54 @@ function initButtons() {
     const hr = document.createElement("hr");
     const creatorNotesBlock = document.getElementById("spoiler_free_desc");
     creatorNotesBlock.before(charStatusContainer, hr);
+
+    /** Group menu */
+    // @ts-ignore
+    /** @type {HTMLElement} */const groupStatusContainer = charStatusContainer.cloneNode(true);
+    groupStatusContainer.classList.add("wide100p");
+    groupStatusContainer.firstElementChild.classList.add("border", "border-faded");
+
+    const groupPersonasBtn = groupStatusContainer.querySelector('.menu_button.fa-users-cog');
+    groupPersonasBtn.addEventListener("click", async () => {
+        const metadata = chat_metadata.stat_us_maximus.filter(s => s.is_user);
+        const users = [];
+
+        for (const status of metadata) {
+            const user = getUser(status.avatar);
+
+            if (user) users.push(user);
+        }
+
+        // @ts-ignore
+        if (!users.length) return toastr.warning(t`Personas could not be found in the metadata`);
+
+        return await popupStatusMultiChar(users);
+    });
+
+    const groupPersonaBtn = groupStatusContainer.querySelector('.menu_button.fa-user-cog');
+    groupPersonaBtn.addEventListener("click", async () => {
+        const user = getUser();
+
+        // @ts-ignore
+        if (!user) return toastr.warning(t`The persona could not be found`);
+
+        return await popupStatusSingleChar(user);
+    });
+
+    const groupMembersButton = groupStatusContainer.querySelector('.menu_button.fa-table');
+    groupMembersButton.addEventListener("click", async () => {
+        const chars = getActiveParticipants([{avatar: user_avatar}]);
+
+        // @ts-ignore
+        if (!chars.length) return toastr.warning(t`Group members could not be found in the metadata`);
+
+        return await popupStatusMultiChar(chars);
+    });
+
+    const groupChatsBlock = document.getElementById("rm_group_chats_block");
+    groupChatsBlock
+        .querySelector('.inline-drawer')
+        .after(hr.cloneNode(), groupStatusContainer, hr.cloneNode());
 }
 
 (async function initExtension() {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ import { lodash, Popper } from "../../../../lib.js";
     - [X] Highlight row on hover
     - [X] Hide description on disable
     - [X] Reduce font-size
-    - [ ] Button on right nav panel to open user metadata - one for active and another for all
+    - [X] Button on right nav panel to open user metadata - one for active and another for all
     - [X] Use alt title if description is empty
     - [ ] Global Stat not attached to character
     - [X] Fix chat UI select button using a similar approach to character export button - thanks Ross
@@ -1073,29 +1073,56 @@ function initButtons() {
 
     /** Single Character menu */
     const charStatusSpan = document.createElement("span");
-    charStatusSpan.textContent = "Character's Status";
-    charStatusSpan.dataset.i18n = "Character's Status";
+    charStatusSpan.textContent = "Stat-us Maximus";
+    charStatusSpan.dataset.i18n = "Stat-us Maximus";
     charStatusSpan.classList.add("flex-grow-1");
+
+    const personasStatusOpenPopupBtn = document.createElement("div");
+    personasStatusOpenPopupBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-users-cog", "interactable", "m-0");
+    personasStatusOpenPopupBtn.addEventListener("click", async () => {
+        const metadata = chat_metadata.stat_us_maximus.filter(s => s.is_user);
+        const users = [];
+
+        for (const status of metadata) {
+            const user = getParticipant(status.avatar, status.is_user);
+
+            if (user) users.push(user);
+        }
+
+        // @ts-ignore
+        if (!users.length) return toastr.warning(t`Personas could not be found in the metadata`);
+
+        return await popupStatusMultiChar(users);
+    });
+
+    const personaStatusOpenPopupBtn = document.createElement("div");
+    personaStatusOpenPopupBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-user-cog", "interactable", "m-0");
+    personaStatusOpenPopupBtn.addEventListener("click", async () => {
+        const user = getUser();
+
+        // @ts-ignore
+        if (!user) return toastr.warning(t`The persona could not be found`);
+
+        return await popupStatusSingleChar(user);
+    });
 
     const charStatusOpenPopupBtn = document.createElement("div");
     charStatusOpenPopupBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-table", "interactable", "m-0");
     charStatusOpenPopupBtn.addEventListener("click", async () => {
-        if (this_chid !== undefined) {
-            const char = characters[this_chid];
+        // @ts-ignore
+        if (this_chid !== undefined) toastr.warning(t`An active character to edit could not be found`);
 
-            // @ts-ignore
-            if (!char) return toastr.warning(t`The character could not be found`);
-
-            return await popupStatusSingleChar(char);
-        }
+        const char = characters[this_chid];
 
         // @ts-ignore
-        toastr.warning(t`An active character to edit could not be found`);
+        if (!char) return toastr.warning(t`The character could not be found`);
+
+        return await popupStatusSingleChar(char);
     });
 
     const charStatusMenu = document.createElement("div");
     charStatusMenu.classList.add("d-flex", "flex-center-start", "gap-5px");
-    charStatusMenu.append(charStatusSpan, charStatusOpenPopupBtn);
+    charStatusMenu.append(charStatusSpan, personasStatusOpenPopupBtn, personaStatusOpenPopupBtn, charStatusOpenPopupBtn);
 
     const charStatusContainer = document.createElement("div");
     charStatusContainer.classList.add("stat-us-max-custom-css");

--- a/style.css
+++ b/style.css
@@ -226,6 +226,21 @@ div[name="templatesAndPopupsWrapper"] {
         border-color: var(--stat-us-border-color) !important;
     }
 
+    .border-t {
+        border-top: 1px solid;
+        border-color: var(--stat-us-border-color) !important;
+    }
+
+    .border-y {
+        border-top: 1px solid;
+        border-bottom: 1px solid;
+        border-color: var(--stat-us-border-color) !important;
+    }
+
+    .border-faded {
+        --stat-us-border-color: color-mix(in srgb, var(--SmartThemeBorderColor), transparent 25%);
+    }
+
     .text_pole,
     select,
     .menu_button {
@@ -350,6 +365,11 @@ div[name="templatesAndPopupsWrapper"] {
         padding-top: 5px;
     }
 
+    .px-5px {
+        padding-left: 5px;
+        padding-right: 5px;
+    }
+
     .px-10px {
         padding-left: 10px;
         padding-right: 10px;
@@ -360,9 +380,9 @@ div[name="templatesAndPopupsWrapper"] {
         padding-bottom: 5px;
     }
 
-    .px-5px {
-        padding-left: 5px;
-        padding-right: 5px;
+    .py-10px {
+        padding-top: 10px;
+        padding-bottom: 10px;
     }
 
     .m-0 {

--- a/style.css
+++ b/style.css
@@ -141,6 +141,7 @@ div[name="templatesAndPopupsWrapper"] {
     --stat-us-border-color: var(--SmartThemeBorderColor);
     --stat-us-avatar-height: var(--avatar-base-height);
     --stat-us-avatar-border-radius: 50%;
+    --stat-us-range-margin-top: 5px;
 
     select {
         color: color-mix(in srgb, var(--SmartThemeBodyColor) 50%, transparent);
@@ -510,7 +511,7 @@ div[name="templatesAndPopupsWrapper"] {
         max-width: unset;
 
         input[type="range"] {
-            margin-top: 5px !important;
+            margin-top: var(--stat-us-range-margin-top) !important;
         }
 
         input[type="number"] {


### PR DESCRIPTION
> This was easier to make than expected - Having reusable code is finally paying off
## Commits
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/c308c8b34a372e9cc0b664a72ef9f74c67cf92bb) - Persona status shortcuts in the right nav menu
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/03429c83b3775e81f7593923fc18f872eed20743) - Group members status shortcuts in the right nav menu
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/28/commits/09ec363a73afffaf26d19d5a44399fd7ee667418) - Clean leftover elements
## Planned - Issue #27
- [x] Add button in the character management panel to open the active persona popup menu
- [x] Add button in the character management panel to open the popup menu for all personas in the chat
- [x] Add button in the group management panel to open the popup menu for all character members in the chat