### PR TITLE
QOL Changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-import { extension_settings, saveMetadataDebounced } from "../../../extensions.js";
+import { extension_settings } from "../../../extensions.js";
 import { saveSettingsDebounced, chat_metadata, this_chid, chat, characters, extension_prompts, setExtensionPrompt, extension_prompt_types, user_avatar, substituteParams } from "../../../../script.js";
 import { getGroupMembers, selected_group } from "../../../group-chats.js";
 import { t } from "../../../i18n.js";
-import { createCharStatus, getCharAltValue, getCharStatus, updateCharEntry } from "./source/js/statusControls.js";
+import { createCharStatus, getCharAltValue, getCharStatus, saveMetadataSTUM, updateCharEntry } from "./source/js/statusControls.js";
 import { power_user } from "../../../power-user.js";
 import { registerSlashCommands } from "./source/js/slashCommands.js";
 import { popupStatusMultiChar, popupStatusSingleChar } from "./source/js/popups.js";
@@ -60,6 +60,9 @@ const regexTextInput = /({{text)(::[^{}]*)?(}})/g;
 const regexNumberInput = /({{number)(::-?\d+\.?\d*)?(}})/g;
 const regexBooleanInput = /({{boolean)(::((false)|(true))::[^}\n]+::[^}\n]+)?(}})/g;
 const regexRangeInput = /({{range::)([\d]+(\.[\d]+)?)(::[\d]+(\.[\d]+)?){3}(}})/g;
+const FETCH_STATUS_TIMEOUT_MS = 300;
+
+let fetchStatusTimeout;
 
 export const extensionSettings = extension_settings[extensionName];
 
@@ -436,7 +439,7 @@ function addTracker(status, character) {
         status.is_collapsed = collapse;
 
         toggleVisibility(statusTableBody, collapse);
-        saveMetadataDebounced();
+        saveMetadataSTUM();
     });
 
     const createInputs = (/**@type {String}*/text) => {
@@ -510,7 +513,7 @@ function addTracker(status, character) {
     const createInputStrings = (parent, target) => {
         /**@type {HTMLElement}*/const targetEl = el(parent, target);
         /**@type {NodeListOf<HTMLElement>}*/const chunks = targetEl.querySelectorAll('.chat-input-editor');
-        let newValue = targetEl.querySelector('.text-line').dataset.originalText;
+        let newValue = /**@type {HTMLElement}*/(targetEl.querySelector('.text-line')).dataset.originalText;
 
         let countRange = -1;
         let countText = -1;
@@ -783,7 +786,7 @@ function addTracker(status, character) {
                 return setTimeout(() => {
                     const popupContainer = `.stat-us-max-popup[data-char="${character.avatar}"][data-is-user="${status.is_user}"]`;
                     const popupRowToggle = `.stat-us-max-popup-row[data-uid="${entry.uid}"] .inline-drawer-toggle`;
-                    const drawerToggle = document.querySelector(`${popupContainer} ${popupRowToggle}`);
+                    /**@type {HTMLElement}*/const drawerToggle = document.querySelector(`${popupContainer} ${popupRowToggle}`);
                     drawerToggle.click();
                 }, 50);
             }
@@ -938,7 +941,7 @@ export function processMacros(text, {char = undefined, processInputs = true} = {
     @property {number} [forceDepth.depth]
     @property {String} [generationType]
 
-    @param {FetchOptions} options
+    @param {FetchOptions?} options
 */
 export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDepth = undefined, generationType = ""} = {}) {
     if (!chat_metadata.stat_us_maximus) chat_metadata.stat_us_maximus = [];
@@ -1032,7 +1035,15 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
         );
     }
 
-    saveMetadataDebounced();
+    saveMetadataSTUM();
+}
+
+/**
+    @param {FetchOptions?} options
+*/
+export function fetchStatusDebounced(options = null) {
+    clearTimeout(fetchStatusTimeout);
+    fetchStatusTimeout = setTimeout(() => fetchStatus(options), FETCH_STATUS_TIMEOUT_MS);
 }
 
 export function groupListAvatarsClick(e) {

--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ const defaultSettings = {
     debug: false
 };
 
-const regexTextInput = /({{text)(::[^}\n]*)?(}})/g;
+// ({{text)(::((?!}{2,})[\s\S])*)?(}})
+const regexTextInput = /({{text)(::[^}]*)?(}})/g;
 const regexNumberInput = /({{number)(::-?\d+\.?\d*)?(}})/g;
 const regexBooleanInput = /({{boolean)(::((false)|(true))::[^}\n]+::[^}\n]+)?(}})/g;
 const regexRangeInput = /({{range::)([\d]+(\.[\d]+)?)(::[\d]+(\.[\d]+)?){3}(}})/g;
@@ -449,10 +450,10 @@ function addTracker(status, character) {
         let newText = `<span class="text-line">${parsedText}</span>`;
 
         newText = newText.replaceAll(regexTextInput, (match) => {
-            const value = match.replaceAll(/(({{text(::)?)|(}}))/g, "");
+            const value = match.replaceAll(/((^{{text(::)?)|(}}$))/g, "");
             const input = `
                 <span class="fa-solid fa-t m-0 chat-input-icon select-none cursor-pointer"></span>
-                <input type="text" value="${value}" class="type-text fake-input chat-input-editor" autocomplete="off" size="0">
+                <textarea type="text" class="type-text fake-input chat-input-editor" autocomplete="off" data-stee--handled="1">${value}</textarea>
                 <span class="text-quote"><span class="value ${extensionSettings.showWhiteSpaces ? "show-spaces" : ""}">${value}</span></span>
             `;
 
@@ -463,7 +464,7 @@ function addTracker(status, character) {
             const value = match.replaceAll(/(({{number(::)?)|(}}))/g, "");
             const input = `
                 <span class="fa-solid fa-n m-0 chat-input-icon select-none cursor-pointer"></span>
-                <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0">
+                <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0" />
                 <span class="text-quote">
                     <span class="value font-monospace">${value}</span>
                     <span class="d-inline-flex gap-0 text-body cursor-pointer fs-normal">
@@ -482,7 +483,7 @@ function addTracker(status, character) {
             const trueValue = props[1] ?? "true";
             const falseValue = props[2] ?? "false";
             const input = `
-                <input type="checkbox" ${checked === "true" ? "checked" : ""} data-true="${trueValue}" data-false="${falseValue}" class="type-checkbox m-0 chat-input-editor">
+                <input type="checkbox" ${checked === "true" ? "checked" : ""} data-true="${trueValue}" data-false="${falseValue}" class="type-checkbox m-0 chat-input-editor" />
                 <span class="text-quote"> ${checked === "true" ? trueValue : falseValue}</span>
             `;
 
@@ -497,8 +498,8 @@ function addTracker(status, character) {
             const value = props[3];
             const input = `
                 <span class="d-flex flex-col flex-center gap-0 type-range chat-input-editor">
-                    <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-slider">
-                    <input type="number" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-input">
+                    <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-slider" />
+                    <input type="number" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-input" />
                 </span>
             `;
 
@@ -534,14 +535,15 @@ function addTracker(status, character) {
                 newMacro = `{{range::${min}::${max}::${step}::${value}}}`;
             }
 
-            if (chunk instanceof HTMLInputElement) {
-                if (chunk.classList.contains("type-text")) {
-                    const value = chunk.value;
-                    index = ++countText;
-                    match = regexTextInput;
-                    newMacro = `{{text${value.length > 0 ? "::" : ""}${value}}}`;
-                }
+            if (chunk instanceof HTMLTextAreaElement) {
+                const value = chunk.value;
+                index = ++countText;
+                match = regexTextInput;
+                newMacro = `{{text${value.length > 0 ? "::" : ""}${value}}}`;
+            }
 
+
+            if (chunk instanceof HTMLInputElement) {
                 if (chunk.classList.contains("type-number")) {
                     const value = chunk.value;
                     index = ++countNumber;
@@ -614,13 +616,15 @@ function addTracker(status, character) {
             });
 
             el(newRow, el_target)
-            .querySelectorAll('input.chat-input-editor')
-            .forEach((/**@type {HTMLInputElement}*/input) => {
+            .querySelectorAll('.chat-input-editor:not(.type-range)')
+            .forEach((/**@type {HTMLInputElement|HTMLTextAreaElement}*/input) => {
 
                 if (input.type === "checkbox") {
+                    // @ts-ignore
                     input.nextElementSibling.textContent = " " + (input.checked ? input.dataset.true : input.dataset.false);
 
                     input.addEventListener("input", () => {
+                        // @ts-ignore
                         input.nextElementSibling.textContent = " " + (input.checked ? input.dataset.true : input.dataset.false);
 
                         el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
@@ -711,7 +715,7 @@ function addTracker(status, character) {
                     });
 
                     if (input.classList.contains("type-number")) {
-                        input.addEventListener("keydown", (e) => {
+                        input.addEventListener("keydown", (/**@type {KeyboardEvent}*/e) => {
                             if (!["ArrowUp", "ArrowDown"].includes(e.key)) return setTimeout(() => updateCaretDisplay(input, lastValid), 10);
 
                             e.preventDefault();
@@ -731,7 +735,7 @@ function addTracker(status, character) {
             });
 
             el(newRow, el_target)
-            .querySelectorAll('span.chat-input-editor')
+            .querySelectorAll('.chat-input-editor.type-range')
             .forEach((/**@type {HTMLSpanElement}*/span) => {
                 /**@type {HTMLInputElement}*/const inputNumber = span.querySelector('input[type="number"]');
                 /**@type {HTMLInputElement}*/const inputRange = span.querySelector('input[type="range"]');

--- a/index.js
+++ b/index.js
@@ -1041,7 +1041,7 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
 /**
     @param {FetchOptions?} options
 */
-export function fetchStatusDebounced(options = null) {
+export function fetchStatusDebounced(options = {}) {
     clearTimeout(fetchStatusTimeout);
     fetchStatusTimeout = setTimeout(() => fetchStatus(options), FETCH_STATUS_TIMEOUT_MS);
 }

--- a/index.js
+++ b/index.js
@@ -376,7 +376,10 @@ function addTracker(status, character) {
         <tr>
             <th scope="col">
                 <div class="d-flex w-100 flex-center-between p-10px">
-                    <span>Status - ${character.name}</span>
+                    <span>
+                        <span class="stat-us-max-chat-title-prefix">Status - </span>
+                        <span class="stat-us-max-chat-title">${character.name}</span>
+                    </span>
                     <div class="d-flex flex-center">
                         <div class="menu_button menu_button_icon fa-solid fa-eye interactable m-0"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-pen interactable m-0"></div>

--- a/index.js
+++ b/index.js
@@ -914,8 +914,17 @@ export function processMacros(text, {char = undefined, processInputs = true} = {
 
 /**
     MARK:fetchStatus()
+    @typedef {object} FetchOptions
+    @property {boolean} [forceUIUpdate]
+    @property {number} [depthModifier]
+    @property {object} [forceDepth]
+    @property {String} [forceDepth.avatar]
+    @property {number} [forceDepth.depth]
+    @property {String} [generationType]
+
+    @param {FetchOptions} options
 */
-export function fetchStatus({forceUIUpdate = false, depthModifier = 0, newMessID = (chat.length - 1), generationType = ""} = {}) {
+export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDepth = undefined, generationType = ""} = {}) {
     if (!chat_metadata.stat_us_maximus) chat_metadata.stat_us_maximus = [];
 
     const real_chat = !extension_settings["Presence"] ? chat.slice(chat_metadata.lastInContextMessageId) : chat;
@@ -945,21 +954,29 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, newMessID
 
         if (!character) continue;
 
-        const char_depth = getStatusDepth(real_chat, character, generationType);
+        const statusCustomDepth = Number(data[i].status.forceDepth === "" ? NaN : data[i].status.forceDepth);
+        const ignoreDepthFailSafe = forceDepth?.avatar === character.avatar || statusCustomDepth >= 0;
+
+        const dynamicDepth = getStatusDepth(real_chat, character, generationType);
+        const char_depth = ignoreDepthFailSafe ? {depth: (forceDepth?.depth ?? statusCustomDepth)} : dynamicDepth;
+
+        if (statusCustomDepth >= 0)
+            char_depth.depth = statusCustomDepth;
 
         if (!data[i].status && extensionSettings.autoDetectParticipants)
             data[i].status = createCharStatus(character);
 
         if (!data[i].status) continue;
 
-        const detectedLastMesID = char_depth.last_mes_id + char_depth.depth;
-        const charLastMesID = data[i].status.last_mes_id + data[i].status.depth;
-
         // If chat/status is empty or character is not even in the context
         if (char_depth.depth < 0) continue;
+
+        const detectedLastMesID = dynamicDepth.last_mes_id + dynamicDepth.depth;
+        const charLastMesID = data[i].status.last_mes_id + data[i].status.depth;
+
         if (forceUIUpdate || detectedLastMesID !== charLastMesID) {
-            data[i].status.depth = char_depth.depth;
-            data[i].status.last_mes_id = char_depth.last_mes_id;
+            data[i].status.depth = dynamicDepth.depth;
+            data[i].status.last_mes_id = dynamicDepth.last_mes_id;
             addTracker(data[i].status, character);
         }
 
@@ -967,7 +984,8 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, newMessID
 
         if (!status.entries.length) continue;
 
-        const promptKey = extensionName.toLowerCase() + "-" + char_depth.depth;
+        const promptKey = extensionName.toLowerCase() + "-" + character.avatar;
+        const promptDepth = ignoreDepthFailSafe ? char_depth.depth : char_depth.depth + depthModifier;
         let promptValue = "";
 
         for (const entry of status.entries) {
@@ -992,7 +1010,7 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, newMessID
             promptKey,
             promptValue,
             extension_prompt_types.IN_CHAT,
-            char_depth.depth + depthModifier,
+            promptDepth,
             true,
             status.role
         );

--- a/index.js
+++ b/index.js
@@ -56,8 +56,7 @@ const defaultSettings = {
     debug: false
 };
 
-// ({{text)(::((?!}{2,})[\s\S])*)?(}})
-const regexTextInput = /({{text)(::[^}]*)?(}})/g;
+const regexTextInput = /({{text)(::[^{}]*)?(}})/g;
 const regexNumberInput = /({{number)(::-?\d+\.?\d*)?(}})/g;
 const regexBooleanInput = /({{boolean)(::((false)|(true))::[^}\n]+::[^}\n]+)?(}})/g;
 const regexRangeInput = /({{range::)([\d]+(\.[\d]+)?)(::[\d]+(\.[\d]+)?){3}(}})/g;
@@ -438,22 +437,18 @@ function addTracker(status, character) {
     });
 
     const createInputs = (/**@type {String}*/text) => {
-        const escapedText = lodash.escape(text);
         const parsedText = lodash.escape(substituteParams(processMacros(text, {char: character, processInputs: false}))).replaceAll(/\n/g, "<br>");
 
         if (!extensionSettings.editNumbersFromChat)
-            return `
-                <span class="d-none original-text">${escapedText}</span>
-                <span class="text-line">${parsedText}</span>
-            `;
+            return `<span class="text-line">${parsedText}</span>`;
 
         let newText = `<span class="text-line">${parsedText}</span>`;
 
         newText = newText.replaceAll(regexTextInput, (match) => {
-            const value = match.replaceAll(/((^{{text(::)?)|(}}$))/g, "");
+            const value = match.replaceAll(/((^{{text(::)?)|(}}$))/g, "").replaceAll("<br>", "\n");
             const input = `
                 <span class="fa-solid fa-t m-0 chat-input-icon select-none cursor-pointer"></span>
-                <textarea type="text" class="type-text fake-input chat-input-editor" autocomplete="off" data-stee--handled="1">${value}</textarea>
+                <textarea type="text" class="type-text fake-input chat-input-editor" data-pattern="^[^{}]*$" autocomplete="off" data-stee--handled="1">${value}</textarea>
                 <span class="text-quote"><span class="value ${extensionSettings.showWhiteSpaces ? "show-spaces" : ""}">${value}</span></span>
             `;
 
@@ -464,7 +459,7 @@ function addTracker(status, character) {
             const value = match.replaceAll(/(({{number(::)?)|(}}))/g, "");
             const input = `
                 <span class="fa-solid fa-n m-0 chat-input-icon select-none cursor-pointer"></span>
-                <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0" />
+                <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" data-pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0" />
                 <span class="text-quote">
                     <span class="value font-monospace">${value}</span>
                     <span class="d-inline-flex gap-0 text-body cursor-pointer fs-normal">
@@ -506,13 +501,13 @@ function addTracker(status, character) {
             return input;
         });
 
-        return `<span class="d-none original-text">${escapedText}</span>${newText}`;
+        return newText;
     }
 
     const createInputStrings = (parent, target) => {
         /**@type {HTMLElement}*/const targetEl = el(parent, target);
         /**@type {NodeListOf<HTMLElement>}*/const chunks = targetEl.querySelectorAll('.chat-input-editor');
-        let newValue = targetEl.querySelector('.d-none.original-text').textContent;
+        let newValue = targetEl.querySelector('.text-line').dataset.originalText;
 
         let countRange = -1;
         let countText = -1;
@@ -603,6 +598,7 @@ function addTracker(status, character) {
             destroyElement(el(newRow, el_target).children);
 
             el(newRow, el_target).innerHTML = createInputs(text);
+            el(newRow, el_target).querySelector('.text-line').dataset.originalText = text;
 
             if (!extensionSettings.editNumbersFromChat) return;
 
@@ -703,8 +699,8 @@ function addTracker(status, character) {
                     });
 
                     input.addEventListener("input", () => {
-                        if (input.hasAttribute("pattern")) {
-                            const regex = new RegExp(input.getAttribute("pattern"));
+                        if (input.dataset.pattern) {
+                            const regex = new RegExp(input.dataset.pattern);
 
                             if (regex.test(input.value)) lastValid = input.value;
                             else input.value = lastValid;

--- a/index.js
+++ b/index.js
@@ -770,7 +770,24 @@ function addTracker(status, character) {
             formDebounceTimer = setTimeout(() => form.requestSubmit(), DEBOUNCE_MS);
         });
 
-        killSwitch.addEventListener("click", (e) => {
+        killSwitch.addEventListener('pointerdown', e =>
+            document.addEventListener('contextmenu', e => e.preventDefault(), {once: true})
+        );
+
+        killSwitch.addEventListener("pointerup", (/**@type {PointerEvent}*/e) => {
+            e.preventDefault();
+
+            if (e.button === 2) {
+                popupStatusSingleChar(character);
+
+                return setTimeout(() => {
+                    const popupContainer = `.stat-us-max-popup[data-char="${character.avatar}"][data-is-user="${status.is_user}"]`;
+                    const popupRowToggle = `.stat-us-max-popup-row[data-uid="${entry.uid}"] .inline-drawer-toggle`;
+                    const drawerToggle = document.querySelector(`${popupContainer} ${popupRowToggle}`);
+                    drawerToggle.click();
+                }, 50);
+            }
+
             toggleSwitch(killSwitch, (state) => {
                 el(form, 'input[name="enabled"]').value = state;
                 toggleVisibility(el(newRow, '.status-separator'), !state);

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,5 +1,6 @@
 import { characters, chat, chat_metadata, event_types, eventSource, scrollChatToBottom, this_chid, user_avatar } from "../../../../../../script.js";
 import { selected_group } from "../../../../../group-chats.js";
+import { power_user } from "../../../../../power-user.js";
 import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatus, fetchStatusDebounced, getActiveParticipants, getStatusDepth, log } from "../../index.js";
 import { createCharStatus, fillMissingMetadata, getCharStatus } from "./statusControls.js";
 
@@ -51,12 +52,16 @@ export function startListeners() {
 
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, async (...args) => {
         log("CHARACTER_MESSAGE_RENDERED", args);
-        fetchStatusDebounced();
+        fetchStatus();
+
+        if (power_user.auto_scroll_chat_to_bottom) scrollChatToBottom();
     });
 
     eventSource.on(event_types.USER_MESSAGE_RENDERED, async (...args) => {
         log("USER_MESSAGE_RENDERED", args);
-        fetchStatusDebounced({depthModifier: 1});
+        fetchStatus({depthModifier: 1});
+
+        if (power_user.auto_scroll_chat_to_bottom) scrollChatToBottom();
     });
 
     /**

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,5 +1,4 @@
-import { chat, chat_metadata, event_types, eventSource, scrollChatToBottom } from "../../../../../../script.js";
-import { saveMetadataDebounced } from "../../../../../extensions.js";
+import { characters, chat, chat_metadata, event_types, eventSource, scrollChatToBottom, this_chid, user_avatar } from "../../../../../../script.js";
 import { selected_group } from "../../../../../group-chats.js";
 import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatus, getActiveParticipants, getStatusDepth, log } from "../../index.js";
 import { createCharStatus, fillMissingMetadata, getCharStatus } from "./statusControls.js";
@@ -52,20 +51,44 @@ export function startListeners() {
 
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, async (...args) => {
         log("CHARACTER_MESSAGE_RENDERED", args);
-        fetchStatus({newMessID: args[0]});
+        fetchStatus();
     });
 
     eventSource.on(event_types.USER_MESSAGE_RENDERED, async (...args) => {
         log("USER_MESSAGE_RENDERED", args);
-        fetchStatus({newMessID: args[0], depthModifier: 1});
+        fetchStatus({depthModifier: 1});
     });
+
+    /**
+        @param {import("../../index.js").FetchOptions} options
+        @param {string} genType
+    */
+    function setActiveCharacterStat(options, genType) {
+        let avatar;
+
+        if (genType === "impersonate")
+            avatar = user_avatar;
+        else if (genType === "continue" && chat.at(-1)?.is_user)
+            avatar = chat.at(-1).force_avatar.replace(/(user avatars\/)|(\/thumbnail\?type=persona&file=)/i, "");
+        else if (this_chid !== undefined)
+            avatar = characters[this_chid].avatar;
+        else return;
+
+        options.forceDepth = {avatar: avatar, depth: 0};
+    }
 
     eventSource.makeLast(event_types.GENERATION_AFTER_COMMANDS, async (...args) => {
         log("GENERATION_AFTER_COMMANDS", args);
 
+        /**@type {import("../../index.js").FetchOptions}*/
         const options = {depthModifier: 1};
 
-        if (typeof args[0] === "string") options.generationType = args[0];
+        if (typeof args[0] === "string") {
+            options.generationType = args[0];
+
+            const genType = args[0];
+            setActiveCharacterStat(options, genType);
+        }
 
         fetchStatus(options);
     });
@@ -83,8 +106,6 @@ export function startListeners() {
     eventSource.on(event_types.MESSAGE_DELETED, async (...args) => {
         log("MESSAGE_DELETED", args);
 
-        const id = (args[0] ?? chat.length) - 1;
-
-        fetchStatus({newMessID: id});
+        fetchStatus();
     });
 }

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,6 +1,6 @@
 import { characters, chat, chat_metadata, event_types, eventSource, scrollChatToBottom, this_chid, user_avatar } from "../../../../../../script.js";
 import { selected_group } from "../../../../../group-chats.js";
-import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatus, getActiveParticipants, getStatusDepth, log } from "../../index.js";
+import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatusDebounced, getActiveParticipants, getStatusDepth, log } from "../../index.js";
 import { createCharStatus, fillMissingMetadata, getCharStatus } from "./statusControls.js";
 
 /*
@@ -45,18 +45,18 @@ export function startListeners() {
         callbacksClickValueUID.map(c => c.popper?.destroy()).splice(0);
 
         fillMissingMetadata();
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
         scrollChatToBottom();
     });
 
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, async (...args) => {
         log("CHARACTER_MESSAGE_RENDERED", args);
-        fetchStatus();
+        fetchStatusDebounced();
     });
 
     eventSource.on(event_types.USER_MESSAGE_RENDERED, async (...args) => {
         log("USER_MESSAGE_RENDERED", args);
-        fetchStatus({depthModifier: 1});
+        fetchStatusDebounced({depthModifier: 1});
     });
 
     /**
@@ -90,22 +90,22 @@ export function startListeners() {
             setActiveCharacterStat(options, genType);
         }
 
-        fetchStatus(options);
+        fetchStatusDebounced(options);
     });
 
     eventSource.on(event_types.MORE_MESSAGES_LOADED, async (...args) => {
         log("MORE_MESSAGES_LOADED", args);
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
     });
 
     eventSource.on(event_types.MESSAGE_EDITED, async (...args) => {
         log("MESSAGE_EDITED", args);
-        fetchStatus();
+        fetchStatusDebounced();
     });
 
     eventSource.on(event_types.MESSAGE_DELETED, async (...args) => {
         log("MESSAGE_DELETED", args);
 
-        fetchStatus();
+        fetchStatusDebounced();
     });
 }

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,6 +1,6 @@
 import { characters, chat, chat_metadata, event_types, eventSource, scrollChatToBottom, this_chid, user_avatar } from "../../../../../../script.js";
 import { selected_group } from "../../../../../group-chats.js";
-import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatusDebounced, getActiveParticipants, getStatusDepth, log } from "../../index.js";
+import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatus, fetchStatusDebounced, getActiveParticipants, getStatusDepth, log } from "../../index.js";
 import { createCharStatus, fillMissingMetadata, getCharStatus } from "./statusControls.js";
 
 /*
@@ -45,7 +45,7 @@ export function startListeners() {
         callbacksClickValueUID.map(c => c.popper?.destroy()).splice(0);
 
         fillMissingMetadata();
-        fetchStatusDebounced({forceUIUpdate: true});
+        fetchStatus({forceUIUpdate: true});
         scrollChatToBottom();
     });
 
@@ -90,7 +90,7 @@ export function startListeners() {
             setActiveCharacterStat(options, genType);
         }
 
-        fetchStatusDebounced(options);
+        fetchStatus(options);
     });
 
     eventSource.on(event_types.MORE_MESSAGES_LOADED, async (...args) => {

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -1,11 +1,10 @@
 import { characters, extension_prompt_roles } from "../../../../../../script.js";
-import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { t } from "../../../../../i18n.js";
 import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
-import { log, destroyElement, fetchStatus } from "../../index.js";
-import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue } from "./statusControls.js";
+import { log, destroyElement, fetchStatusDebounced } from "../../index.js";
+import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, saveMetadataSTUM } from "./statusControls.js";
 
 /*  # TODO
     - [X] Select for alt_values
@@ -561,7 +560,7 @@ export function formStatusSingleChar(char) {
     selectEntryRole.addEventListener("input", () => {
         metadata.role = Number(selectEntryRole.value);
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
     });
 
     numberAreaForDepth.addEventListener("input", () => {
@@ -569,7 +568,7 @@ export function formStatusSingleChar(char) {
 
         clearTimeout(forceDepthDebounceTimer);
 
-        forceDepthDebounceTimer = window.setTimeout(() => saveMetadataDebounced(), DEBOUNCE_MS);
+        forceDepthDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     })
 
     textareaStatusSeparator.addEventListener("input", () => {
@@ -577,7 +576,7 @@ export function formStatusSingleChar(char) {
 
         clearTimeout(separatorDebounceTimer);
 
-        separatorDebounceTimer = window.setTimeout(() => saveMetadataDebounced(), DEBOUNCE_MS);
+        separatorDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     });
 
     textareaDefEntrySeparator.addEventListener("input", () => {
@@ -585,7 +584,7 @@ export function formStatusSingleChar(char) {
 
         clearTimeout(defEntrySeparatorDebounceTimer);
 
-        defEntrySeparatorDebounceTimer = window.setTimeout(() => saveMetadataDebounced(), DEBOUNCE_MS);
+        defEntrySeparatorDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     });
 
     textareaStatusPrefix.addEventListener("input", () => {
@@ -593,7 +592,7 @@ export function formStatusSingleChar(char) {
 
         clearTimeout(prefixDebounceTimer);
 
-        prefixDebounceTimer = window.setTimeout(() => saveMetadataDebounced(), DEBOUNCE_MS);
+        prefixDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     });
 
     textareaStatusSuffix.addEventListener("input", () => {
@@ -601,7 +600,7 @@ export function formStatusSingleChar(char) {
 
         clearTimeout(suffixDebounceTimer);
 
-        suffixDebounceTimer = window.setTimeout(() => saveMetadataDebounced(), DEBOUNCE_MS);
+        suffixDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     });
 
     cloneStatsBtn.addEventListener("click", async () => {
@@ -676,7 +675,7 @@ export async function popupStatusSingleChar(char) {
         onClose: async () => destroyElement(container)
     });
 
-    fetchStatus({forceUIUpdate: true});
+    fetchStatusDebounced({forceUIUpdate: true});
 }
 
 export async function popupStatusMultiChar(chars) {
@@ -696,5 +695,5 @@ export async function popupStatusMultiChar(chars) {
         onClose: async () => destroyElement(content)
     });
 
-    fetchStatus({forceUIUpdate: true});
+    fetchStatusDebounced({forceUIUpdate: true});
 }

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -5,7 +5,7 @@ import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
 import { log, destroyElement, fetchStatus } from "../../index.js";
-import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus } from "./statusControls.js";
+import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue } from "./statusControls.js";
 
 /*  # TODO
     - [X] Select for alt_values
@@ -148,11 +148,11 @@ export function formStatusSingleChar(char) {
     // @ts-ignore
     if (!metadata) return toastr.error(t`No metadata was found for the character -${char?.name}-`);
 
-    const createInputLabel = (/**@type {HTMLInputElement|HTMLSelectElement}*/input, mw = "auto") => {
+    const createInputLabel = (/**@type {HTMLInputElement|HTMLSelectElement}*/input, mw = "mw-unset") => {
         const labelTemplateSpan = document.createElement("small");
         labelTemplateSpan.dataset.i18n = (input instanceof HTMLInputElement) ? input.placeholder : input.ariaPlaceholder;
         labelTemplateSpan.innerText = (input instanceof HTMLInputElement) ? input.placeholder : input.ariaPlaceholder;
-        labelTemplateSpan.classList.add("text-center", "input-label");
+        labelTemplateSpan.classList.add("text-center", "input-label", "white-space-nowrap", "mb-3px");
 
         const labelTemplate = document.createElement("div");
         labelTemplate.classList.add("d-flex", "flex-col", "gap-0", "flex-grow-1", mw);
@@ -202,6 +202,14 @@ export function formStatusSingleChar(char) {
 
         selectEntryRole.append(option);
     }
+
+    const numberAreaForDepth = document.createElement("input");
+    numberAreaForDepth.autocomplete = "off";
+    numberAreaForDepth.type = "number";
+    numberAreaForDepth.placeholder = t`Custom Depth`;
+    numberAreaForDepth.title = t`Overrides the behavior of attaching the in-depth prompt dynamically before the last message, to using a constant depth`;
+    numberAreaForDepth.value = metadata.forceDepth ?? "";
+    numberAreaForDepth.classList.add("text_pole", "m-0");
 
     const textareaStatusSeparator = document.createElement("input");
     textareaStatusSeparator.autocomplete = "off";
@@ -256,6 +264,7 @@ export function formStatusSingleChar(char) {
     statInputsWrapper.classList.add("d-flex", "flex-end-start", "w-100", "gap-5px", "stat-wrapper");
     statInputsWrapper.append(
         createInputLabel(selectEntryRole),
+        createInputLabel(numberAreaForDepth),
         createInputLabel(textareaStatusSeparator),
         createInputLabel(textareaDefEntrySeparator),
         createInputLabel(textareaStatusPrefix),
@@ -397,6 +406,7 @@ export function formStatusSingleChar(char) {
     const DEBOUNCE_MS = 400;
     let formDebounceTimer;
     let altKeyDebounceTimer;
+    let forceDepthDebounceTimer;
     let separatorDebounceTimer;
     let defEntrySeparatorDebounceTimer;
     let prefixDebounceTimer;
@@ -553,6 +563,14 @@ export function formStatusSingleChar(char) {
 
         saveMetadataDebounced();
     });
+
+    numberAreaForDepth.addEventListener("input", () => {
+        metadata.forceDepth = parseValue(numberAreaForDepth.value);
+
+        clearTimeout(forceDepthDebounceTimer);
+
+        forceDepthDebounceTimer = window.setTimeout(() => saveMetadataDebounced(), DEBOUNCE_MS);
+    })
 
     textareaStatusSeparator.addEventListener("input", () => {
         metadata.separator = un_escapeNewlines(textareaStatusSeparator.value);

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -1,4 +1,5 @@
-import { characters, extension_prompt_roles } from "../../../../../../script.js";
+import { lodash } from "../../../../../../lib.js";
+import { characters, extension_prompt_roles, getThumbnailUrl } from "../../../../../../script.js";
 import { t } from "../../../../../i18n.js";
 import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
@@ -135,8 +136,8 @@ async function clonePopup(char) {
 
 function getFullCharAvatar(status) {
     // TODO getThumbnailUrl - on next release
-    if (status.is_user) return "User Avatars/" + status.avatar;
-    else return "/thumbnail?type=avatar&file=" + status.avatar;
+    if (status.is_user) return getThumbnailUrl("persona", status.avatar); //"/thumbnail?type=persona&file=" + status.avatar;
+    else return getThumbnailUrl("avatar", status.avatar); //"/thumbnail?type=avatar&file=" + status.avatar;
 }
 
 export function formStatusSingleChar(char) {
@@ -176,7 +177,7 @@ export function formStatusSingleChar(char) {
     /** Create Menu header. */
     const avatar = document.createElement("img");
     avatar.alt = "Avatar";
-    avatar.title = metadata.avatar;
+    avatar.title = lodash.escape(metadata.avatar);
     avatar.src = getFullCharAvatar(metadata);
 
     const avatarContainer = document.createElement("div");

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -22,7 +22,7 @@ import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCh
     - [X] Status clone button
     - [X] Status delete button
     - [X] Entries block prefix/suffix
-    - [ ] Custom depth buttons - dynamic depth if undefined
+    - [X] Custom depth buttons - dynamic depth if undefined
     - [X] Fucking labels
 */
 

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -1,6 +1,5 @@
 import { Fuse } from "../../../../../../lib.js";
 import { chat_metadata } from "../../../../../../script.js";
-import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { t } from "../../../../../i18n.js";
 import { SlashCommand } from "../../../../../slash-commands/SlashCommand.js";
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from "../../../../../slash-commands/SlashCommandArgument.js";
@@ -9,8 +8,8 @@ import { commonEnumProviders, enumIcons } from "../../../../../slash-commands/Sl
 import { enumTypes, SlashCommandEnumValue } from "../../../../../slash-commands/SlashCommandEnumValue.js";
 import { SlashCommandExecutor } from "../../../../../slash-commands/SlashCommandExecutor.js";
 import { SlashCommandParser } from "../../../../../slash-commands/SlashCommandParser.js";
-import { fetchStatus, getParticipant, log } from "../../index.js";
-import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, updateCharAltValue, updateCharEntry, updateCharStatus } from "./statusControls.js";
+import { fetchStatusDebounced, getParticipant, log } from "../../index.js";
+import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, saveMetadataSTUM, updateCharAltValue, updateCharEntry, updateCharStatus } from "./statusControls.js";
 
 /*  # TODO
     - [X] Command to create Status data
@@ -222,7 +221,7 @@ async function commandDeleteStatus(args, value) {
 
         if (!success) return "false";
 
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
 
         return "true";
     } catch (error) {
@@ -328,7 +327,7 @@ function commandSetEntryField(args, value = "") {
         formData.set(field, String(value));
 
         updateCharEntry(character, parsed_uid, formData);
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
     } catch (error) {
         // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
@@ -387,7 +386,7 @@ function commandDeleteEntry(args, value) {
 
         const deletionSucceed = removeCharEntry(character, parsed_uid);
 
-        if (deletionSucceed) fetchStatus({forceUIUpdate: true});
+        if (deletionSucceed) fetchStatusDebounced({forceUIUpdate: true});
 
         return String(deletionSucceed ?? false);
     } catch (error) {
@@ -426,7 +425,7 @@ function commandSwitchEntryValue(args, value) {
         formData.set("value_uid", alt.uid);
 
         updateCharEntry(character, parsed_uid, formData);
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
 
         return "";
     } catch (error) {
@@ -465,7 +464,7 @@ function commandCreateEntryAltValue(args, value = "") {
             updateCharAltValue(character, parsed_uid, alt.uid, formData);
         }
 
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
 
         return String(alt.uid ?? "");
     } catch (error) {
@@ -555,7 +554,7 @@ function commandSetAltEntryField(args, value = "") {
         formData.set(field, String(value));
 
         updateCharAltValue(character, parsed_uid, parsed_altuid, formData);
-        fetchStatus({forceUIUpdate: true});
+        fetchStatusDebounced({forceUIUpdate: true});
     } catch (error) {
         // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
@@ -620,7 +619,7 @@ function commandDeleteAltEntry(args, value) {
 
         const deletionSucceed = removeCharAltValue(character, parsed_uid, parsed_altuid);
 
-        if (deletionSucceed) fetchStatus({forceUIUpdate: true});
+        if (deletionSucceed) fetchStatusDebounced({forceUIUpdate: true});
 
         return String(deletionSucceed ?? false);
     } catch (error) {
@@ -637,7 +636,7 @@ function commandDeleteAltEntry(args, value) {
 async function commandDeleteChatStatus() {
     try {
         delete SillyTavern.getContext().chatMetadata.stat_us_maximus;
-        saveMetadataDebounced();
+        saveMetadataSTUM();
     } catch (error) {
         return "false";
     }

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -10,7 +10,7 @@ import { enumTypes, SlashCommandEnumValue } from "../../../../../slash-commands/
 import { SlashCommandExecutor } from "../../../../../slash-commands/SlashCommandExecutor.js";
 import { SlashCommandParser } from "../../../../../slash-commands/SlashCommandParser.js";
 import { fetchStatus, getParticipant, log } from "../../index.js";
-import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, updateCharAltValue, updateCharEntry } from "./statusControls.js";
+import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, updateCharAltValue, updateCharEntry, updateCharStatus } from "./statusControls.js";
 
 /*  # TODO
     - [X] Command to create Status data
@@ -43,19 +43,29 @@ function getParticipantFromName(name = "") {
 }
 
 /** Accepted key values and their descriptions */
+const acceptedStatusFields = {
+    // role: "Determines the role at which the status is sent to the prompt",
+    // is_collapsed: "Wether to collapse or expand the status block in the chat",
+    separator: "The separator used between entries",
+    def_entry_separator: "Default title/value separator set when creating an entry",
+    prefix: "Text added before the first entry",
+    suffix: "Text added after the last entry"
+};
+
+/** Accepted key values and their descriptions */
 const acceptedEntryFields = {
     enabled: "Determines if the entry gets added to the prompt",
     key: "Title of the entry",
     value: "Value of the entry",
     separator: "Separator between the key and value",
     // display_position: "Order at which the entry gets inserted (starts at 0)"
-}
+};
 
 /** Accepted alt key values and their descriptions */
 const acceptedAltEntryFields = {
     key: "Nickname of the alt entry - only used in the select button",
     value: "Value of the alt entry"
-}
+};
 
 /** Enum providers for slash commands autocomplete */
 const customEnumProviders = {
@@ -69,6 +79,13 @@ const customEnumProviders = {
 
         return chars_filtered.map(char => new SlashCommandEnumValue(char.name, char.avatar, enumTypes.name, enumIcons.character));
     },
+
+    /** All modifiable entry fields.
+        @returns {SlashCommandEnumValue[]}
+    */
+    statusFields: () => Object
+        .entries(acceptedStatusFields)
+        .map(([key, value]) => new SlashCommandEnumValue(key, value, enumTypes.enum, enumIcons.enum)),
 
     /** All modifiable entry fields.
         @returns {SlashCommandEnumValue[]}
@@ -126,7 +143,7 @@ const customEnumProviders = {
 
         return entry.alt_values.map(alt => new SlashCommandEnumValue(String(alt.uid), buildUIDsComment(alt), enumTypes.number, enumIcons.key));
     }
-}
+};
 
 /** Creates status data for a character
     @param {object} args
@@ -155,6 +172,35 @@ async function commandCreateStatus(args, value) {
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
 
         return "false";
+    }
+}
+
+/** Updates the value of an entry field
+    @param {object} args
+    @param {String} args.char - Character name
+    @param {String} args.field - Field to modify
+    @param {String|SlashCommandClosure|String[]|SlashCommandClosure[]} value - New value of the selected field
+    @returns {String} Empty string
+*/
+function commandSetStatusField(args, value = "") {
+    try {
+        const {char = "", field = ""} = args;
+
+        const character = getParticipantFromName(char);
+        const acceptedFields = Object.keys(acceptedStatusFields);
+
+        if (!acceptedFields.some(key => key === field)) throw new Error(`Invalid field "${field}"`);
+        if (!character) throw new Error(`The character "${char}" could not be found in the metadata`);
+
+        const formData = new FormData();
+        formData.set(field, String(value));
+
+        updateCharStatus(character, formData);
+    } catch (error) {
+        // @ts-ignore
+        toastr.error(t`Failed to save Status Metadata: ${error.message}`);
+    } finally {
+        return "";
     }
 }
 
@@ -631,6 +677,49 @@ export function registerSlashCommands() {
                 <ul>
                     <li>
                         <pre><code>/stum-create-status char="Tom"</code></pre>
+                    </li>
+                </ul>
+            </div>`,
+        })
+    );
+
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "stum-set-status-field",
+            callback: commandSetStatusField,
+            returns: 'Empty string',
+            namedArgumentList: [
+                SlashCommandNamedArgument.fromProps({
+                    name: 'char',
+                    description: 'Name of the character',
+                    typeList: [ARGUMENT_TYPE.STRING],
+                    isRequired: true,
+                    enumProvider: customEnumProviders.participantNames
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: 'field',
+                    description: 'Field to update - default value',
+                    typeList: [ARGUMENT_TYPE.STRING],
+                    isRequired: false,
+                    enumProvider: customEnumProviders.statusFields
+                })
+            ],
+            unnamedArgumentList: [
+                SlashCommandArgument.fromProps({
+                    description: 'New value of the field - default to empty text',
+                    isRequired: true,
+                    typeList: [ARGUMENT_TYPE.STRING]
+                })
+            ],
+            helpString: `
+            <div>
+                Set the value of one of the core fields of you Character's status. If you use ST's macros as the field value, you'll need to escape them like this: {\\{char}}.
+            </div>
+            <div>
+                <strong>Example</strong>
+                <ul>
+                    <li>
+                        <pre><code>/stum-set-status-field char="Tom" field="prefix" "{{name}}: "</code></pre>
                     </li>
                 </ul>
             </div>`,

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -4,6 +4,14 @@ import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { t } from "../../../../../i18n.js";
 import { un_escapeNewlines } from "./popups.js";
 
+let saveDataTimeout;
+const SAVE_DATA_TIMEOUT_MS = 300;
+
+export function saveMetadataSTUM() {
+    clearTimeout(saveDataTimeout)
+    saveDataTimeout = setTimeout(saveMetadataDebounced, SAVE_DATA_TIMEOUT_MS);
+}
+
 export function getFreeDataUid(data) {
     if (!data?.length) return 0;
 
@@ -40,7 +48,8 @@ export function addCharAltValue(character, entry_uid, alt_value = "") {
         };
 
         entry.alt_values.push(newAlt);
-        saveMetadataDebounced();
+
+        saveMetadataSTUM();
 
         return newAlt;
     } catch (error) {
@@ -91,7 +100,7 @@ export function updateCharAltValue(character, entry_uid, alt_uid, formData) {
 
         if (entry.value_uid === alt.uid) entry.value = alt.value;
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return alt;
     } catch (error) {
@@ -119,7 +128,7 @@ export function removeCharAltValue(character, entry_uid, alt_uid) {
             entry.value_uid = entry.alt_values[0].uid;
         }
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return true;
     } catch (error) {
@@ -156,7 +165,7 @@ export function addCharEntry(character, entry_key = "", entry_value = "") {
 
         char_status.entries.push(newEntry);
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return newEntry;
     } catch (error) {
@@ -188,7 +197,7 @@ export function refreshCharEntryDisplay(character, display_order) {
 
         char_status.entries = ordered_data;
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
     } catch (error) {
         // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
@@ -258,7 +267,7 @@ export function updateCharEntry(character, entry_uid, formData) {
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return entry;
     } catch (error) {
@@ -284,7 +293,7 @@ export function removeCharEntry(character, entry_uid = -1) {
             .filter(s => s.uid !== Number(entry_uid));
 
         getLastDisplayPosition(char_status.entries);
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return true;
     } catch (error) {
@@ -315,7 +324,7 @@ export function createCharStatus(character, depth = -1) {
 
         chat_metadata.stat_us_maximus.push(status);
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return status;
     } catch (error) {
@@ -358,7 +367,7 @@ export function updateCharStatus(character, formData) {
             status[key] = parsedValue;
         }
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return status;
     } catch (error) {
@@ -409,7 +418,7 @@ export function transferCharStatus(character, target, {deleteOriginal = false, o
 
         if (deleteOriginal) deleteCharStatus(character);
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return true;
     } catch (error) {
@@ -428,7 +437,7 @@ export function deleteCharStatus(character) {
         chat_metadata.stat_us_maximus = chat_metadata.stat_us_maximus
             .filter(stat => stat.avatar !== character.avatar);
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
         deleteCharTracker(character);
 
         return true;
@@ -496,7 +505,7 @@ export async function fillMissingMetadata() {
             }
         }
 
-        saveMetadataDebounced();
+        saveMetadataSTUM();
 
         return true;
     } catch (error) {

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -342,6 +342,36 @@ export function getCharStatus(character) {
 
 /**
     @param {object} character
+    @param {FormData} formData
+    @returns {object|Boolean}
+*/
+export function updateCharStatus(character, formData) {
+    try {
+        const status = getCharStatus(character);
+
+        if (!status) throw new Error(`Status data for the character ${character.name} could not be found`);
+        if (!formData) throw new Error("Data sent is not valid");
+
+        for (const [key, value] of formData.entries()) {
+            let parsedValue = un_escapeNewlines(parseValue(value));
+
+            status[key] = parsedValue;
+        }
+
+        saveMetadataDebounced();
+
+        return status;
+    } catch (error) {
+        // @ts-ignore
+        toastr.error(t`Failed to save Status Metadata: ${error.message}`);
+        console.error(error.message);
+
+        return false;
+    }
+}
+
+/**
+    @param {object} character
     @param {object} target
     @param {object} [options]
     @param {boolean} [options.deleteOriginal=false]

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -86,7 +86,8 @@ export function updateCharAltValue(character, entry_uid, alt_uid, formData) {
 
         if (!alt) throw new Error(`Alt entry with uid=${alt_uid} not found`);
 
-        for (const [key, value] of formData.entries()) alt[key] = String(value);
+        for (const [key, value] of formData.entries())
+            alt[key] = key === "value" ? un_escapeNewlines(String(value)) : String(value);
 
         if (entry.value_uid === alt.uid) entry.value = alt.value;
 
@@ -217,7 +218,7 @@ export function getCharEntry(character, entry_uid) {
     }
 }
 
-function parseValue(val) {
+export function parseValue(val) {
     if (val === "true")  return true;
     if (val === "false") return false;
 
@@ -244,6 +245,7 @@ export function updateCharEntry(character, entry_uid, formData) {
             let parsedValue = parseValue(value);
 
             if (key === "alt_key") continue;
+            if (key === "value") parsedValue = un_escapeNewlines(parsedValue);
             if (key.includes("separator")) parsedValue = un_escapeNewlines(parsedValue);
 
             entry[key] = parsedValue;
@@ -304,6 +306,7 @@ export function createCharStatus(character, depth = -1) {
             prefix: "",
             suffix: "",
             depth: depth,
+            forceDepth: "",
             last_mes_id: (depth >= 0) ? (chat.length - depth - 1) : (-1),
             is_user: character.is_user ?? false,
             is_collapsed: false,
@@ -416,6 +419,7 @@ const statusTemplate = {
     prefix: "",
     suffix: "",
     depth: -1,
+    forceDepth: "",
     last_mes_id: -1,
     is_user: false,
     is_collapsed: false,

--- a/style.css
+++ b/style.css
@@ -546,9 +546,7 @@ div[name="templatesAndPopupsWrapper"] {
 
     .fake-input {
         position: absolute;
-        inset: 0;
-        width: 0;
-        height: 0;
+        pointer-events: none;
         opacity: 0;
         margin: 0;
         padding: 0;
@@ -572,6 +570,9 @@ div[name="templatesAndPopupsWrapper"] {
 
     .text-line .value.show-spaces {
         background-color: var(--stat-us-show-spaces-color);
+    }
+
+    .text-line .value {
         white-space: break-spaces;
     }
 

--- a/style.css
+++ b/style.css
@@ -86,6 +86,10 @@ div[name="templatesAndPopupsWrapper"] {
 
 .mes[is_user="true"] .table-container.stat-us-max-custom-css {
     background-color: var(--SmartThemeUserMesBlurTintColor);
+
+    .text-line .value.show-spaces {
+        --stat-us-show-spaces-color: color-mix(in srgb, var(--SmartThemeUserMesBlurTintColor), var(--SmartThemeQuoteColor) 12%);
+    }
 }
 
 .mes .table-container.stat-us-max-custom-css {
@@ -136,6 +140,7 @@ div[name="templatesAndPopupsWrapper"] {
     --stat-us-avatar-border-radius: 50%;
     --stat-us-range-margin-top: 5px;
     --stat-us-separator-bottom: linear-gradient(90deg, var(--transparent), color-mix(in srgb, var(--SmartThemeBodyColor), transparent 80%), var(--transparent)) 1;
+    --stat-us-show-spaces-color: color-mix(in srgb, var(--SmartThemeBotMesBlurTintColor), var(--SmartThemeQuoteColor) 12%);
 
     select {
         color: color-mix(in srgb, var(--SmartThemeBodyColor) 50%, transparent);
@@ -523,6 +528,8 @@ div[name="templatesAndPopupsWrapper"] {
         width: 0;
         height: 0;
         opacity: 0;
+        margin: 0;
+        padding: 0;
         border: none;
         background: transparent;
     }
@@ -542,7 +549,7 @@ div[name="templatesAndPopupsWrapper"] {
     }
 
     .text-line .value.show-spaces {
-        background-color: color-mix(in srgb, var(--SmartThemeBlurTintColor), var(--SmartThemeBodyColor) 8%);
+        background-color: var(--stat-us-show-spaces-color);
         white-space: break-spaces;
     }
 

--- a/style.css
+++ b/style.css
@@ -561,6 +561,8 @@ div[name="templatesAndPopupsWrapper"] {
 
     .fake-caret {
         display: inline-block;
+        position: absolute;
+        transform: translateY(0.1em);
         width: 1px;
         height: 1em;
         background-color: var(--SmartThemeBodyColor);

--- a/style.css
+++ b/style.css
@@ -55,6 +55,16 @@ div[name="templatesAndPopupsWrapper"] {
     }
 }
 
+@media screen and (max-width: 1250px) {
+    #stat-us-max-popup-multi-char,
+    .popup:has(.stat-us-max-popup),
+    .stat-us-max-custom-css {
+        .white-space-nowrap {
+            white-space: normal !important;
+        }
+    }
+}
+
 @media screen and (max-width: 1900px) {
     .popup.wide_dialogue_popup:has(.stat-us-max-popup) {
         width: 90vw;
@@ -215,6 +225,10 @@ div[name="templatesAndPopupsWrapper"] {
         color: color-mix(in srgb, currentColor 85%, black);
     }
 
+    .white-space-nowrap {
+        white-space: nowrap;
+    }
+
     .font-monospace {
         font-family: monospace;
     }
@@ -356,6 +370,10 @@ div[name="templatesAndPopupsWrapper"] {
         width: 100%;
     }
 
+    .mw-unset {
+        max-width: unset;
+    }
+
     .mw-7 {
         max-width: 7%;
     }
@@ -414,6 +432,10 @@ div[name="templatesAndPopupsWrapper"] {
 
     .mt-0 {
         margin-top: 0;
+    }
+
+    .mb-3px {
+        margin-bottom: 3px;
     }
 
     .mb-5px {


### PR DESCRIPTION
## Changes
- Allow newlines in text macros from both chat and entry descriptions
- Generating character will have its status injected at depth 0
- Add the ability to set a custom depth for a character
> This overrides dynamic depth behavior and always injects the status at the specified depth
- Add the `/stum-set-status-field` command
> It allows setting text values such as prefix, suffix, separator, and default separator
- Separate the status title in chat into two containers for easier CSS customization
- Prevent the caret in chat macro inputs from resizing the input or adding extra spaces while typing
- Make right-clicking the entry toggle in chat open the status popup with the corresponding entry expanded
- Improve slash command performance
> I wrote a script to set character status, and it literally froze my browser after chaining two commands. It runs like butter now.
- Fix avatar loading in popup menus
## Commits
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/e03b88a68ca8dc2d4b657a4ce5c1c7f49fa3c15c) - Allow newlines in text macros
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/03403d6ee6054c4ca9f1e6006ff18c75920c28ef) - Add custom depth for the status block
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/f8d123c1bb3c847985e925e7b262836e6ec233bd) - Add slash command /stum-set-status-field
- [Update manifest.json](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/e4c1e43862fb28df20a0ff399e6ec6b35a8fbbb6)
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/082f30402087cf0144cf8067441015362a0f3ea5) - Make newlines in text inputs actually work
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/8e8f93c794da6b424b2cb3a14e5404b73aba1c97) - Give chat title easier to customize containers
- [Styles](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/8760a25312710124dbfa19bfe8cb762f2147a8ca) - Sexify the fake caret
> That's a way better looking caret, and it no longer has wonky interactions with the spacing of the line.
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/18110b704bcbef814e879aadc4fee1f1554ce05b) - Open expanded popup drawer on right clicking chat toggle
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/d64e7bd312468705b279aef6e60e019c69c644cd) - Improve slash commands performance
> Debounce metadata updates and UI updates
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/770dc99f7bd319ba3d9395dbdc7dfb1c2b9f3552) - Don't debounce important UI updates
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/85cc4d0675385424c0208af8e01d30662e80aa06) - Scroll chat to bottom correctly on new message
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/commit/0924f2ccb47d1c1b42e9e1e9c5c9c8bf869f4a0d) - Fetch avatars correctly