### PR TITLE
Chat UI overhaul and Optimization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,23 +78,3 @@ jobs:
            - **Merged by**: @${{ steps.pr_details.outputs.user }}
           draft: false
           prerelease: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 'lts/*'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build documentation
-        run: npx jsdoc -c jsdoc.conf.json
-
-      - name: Deploy docs to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./docs
-          user_name: github-actions[bot]
-          user_email: github-actions[bot]@users.noreply.github.com

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,27 @@
 *.mdp
 /docs/
 /docs/*
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/public/*.js.map

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Stat-us Maximus
-Have you ever wanted to keep track of your characters' status? Like...whatever you need. Here's the solution!
-This extension adds a menu per character to have your notes, it is basically a shortcut for lorebooks (it even has a similar menu), but it gets saved per chat file and has a little more features than lorebooks.
+This extension adds a prompt shortcut for your chats. Think of it as a Prompt Manager individual for each character, that is saved per char and only sent if the character is present (or always for individual chats). The extension is not automated by an AI in the background, it adds UI elements in chat to allow you to easily edit everything by hand, and it also gives you slash commands that allow you to edit every field of the status blocks, if you want to add automation/AI automation by yourself via ST Scripts.
+This is not focused for any task in particular, it's all just text, put what you want.
 
-**This is still in development! Please submit any bug you find and feature you want! Either as a GitHub issue or through the ST Discord.**
-
-<img width="100%" alt="image" src="https://github.com/user-attachments/assets/b1ed1902-e714-44db-bccd-afc3b354f32a" />
-<img width="100%" alt="image" src="https://github.com/user-attachments/assets/05ada274-f463-42a5-995b-ae8bd162bee1" />
-<img width="100%" alt="image" src="https://github.com/user-attachments/assets/02eb098a-8174-4169-9bde-5c9608317e70" />
+<img width="100%" alt="image" src="https://github.com/user-attachments/assets/79018421-7396-4a4d-8370-cf802e06b6c5" />
+<img width="100%" alt="image" src="https://github.com/user-attachments/assets/14c92540-4fde-490c-8938-03fa8ab626b0" />
+<img width="100%" alt="image" src="https://github.com/user-attachments/assets/27eb34a3-19b0-4ada-8a7d-dec94a1140db" />
 
 ## Features
 
@@ -14,18 +12,19 @@ This extension adds a menu per character to have your notes, it is basically a s
 - When you open a chat, a status will be added for every character present (either now or in the past).
 - A table with all of the character stats will be added in the last message of the character.
 - The table can be collapsed to save space (the collapsed state saves).
-- Every character status is sent to the chat in a dynamic depth that will adjust to be on top of the last character message.
-- The status can be send as system, user or assistant - default system.
+- Every character status is sent to the chat in a dynamic depth that will adjust to be on top of the last character message - unless it is overriden to be sent at a specific depth.
+- The status can be send as `system`, `user` or `assistant` - defaults to `system`.
 - With macros, you can set inputs in the chat UI to quick edit entries without opening menus.
-- You can set swipes or alt values for each stat entry.
-- You can copy and paste entries between characters from the popup Menu (truck button).
+- You can set swipes (alt values) for each stat entry.
+- You can transfer entries between characters from the popup Menu (truck button).
+- You can copy and paste entries via clipboard from the popup Menu (import/export buttons per entry).
 
 ### Menus
 **Magic wand button** - From the magic wand button (left to the input bar), you can open a popup menu to manage every character status.
 
 **Character Management menu** - In single chats, you can open the status popup menu for the active chat character from the Character Management menu.
 
-**Group Management menu** - In group chats, click the member avatar in the Current Members dropdown to open its status popup menu. You can also click the left button to open the popup menu for all active group members.
+**Group Management menu** - In group chats, click the member avatar in the Current Members dropdown to open its status popup menu. You can also click the buttons from the Character Management menu to edit the status blocks of every character present in chat.
 
 **All chats** - In all chats, click the pen icon at the corner of the status table, placed in the last message of each character, to open its popup menu. You can also open your personas popup from the Management menu; middle button for active persona, and right button for all personas with status data.
 
@@ -48,41 +47,20 @@ This extension adds a menu per character to have your notes, it is basically a s
 - `/stum-fill-missing-metadata` It will fill missing values in the metadata structure - WARN This is a dev command used for bug fixing, only use it if instructed to do so by a developer.
 
 ### Macros
+These macros only work inside status blocks.
 - `{{name}}` Will be replaced with the name of the Status owner.
 - `{{text}} | {{text::Your text here}}` In the chat UI, it will be replaced with a text input. This does not support newlines or curly braces `{}`.
 - `{{number}} | {{number::2048}}` In the chat UI, it will be replaced with a number input. You need to use dots `.` for decimals, commas are not supported.
 - `{{boolean}} | {{boolean::DefaultValueTrueOrFalse::Custom True Label::Custom False Label}}` In the chat UI, it will be replaced with a checkbox. The first parameter is the state of the checkbox, and must either be `true` or `false`. By default, the checkbox labels and value sent to prompt will simply be "true" or "false", but you can set custom texts to be displayed/sent instead with the custom label parameters.
 - `{{range::min::max::step::value}}` In the chat UI, it will be replaced with a range input, the same used in the samplers panel. `min` is the minimum value of the range, `max` is the maximum, `step` is the amount of numbers the input will increase/decrease when the buttons of the input are used, and `value` is the value the input will have. All parameters are `numbers`, and decimals only accept dots.
 
-### Coming Soon
-- [X] Slash commands for adding/updating/deleting status entries.
-- [X] Slash command for switching between entries alt values.
-- [X] Update ugly chat UI.
-- [ ] Shade closed entry drawers in popup menus.
-- [ ] Setting to disable confirm deletion popups.
-- [ ] Setting for default status role.
-- [X] Per-user open status-menu buttons.
-- [X] Button to delete status metadata per character.
-- [X] Expand/collapse all entries per character in popup menus.
-- [X] Status transfer button in popup menus.
-- [X] Status block prefix/suffix in popup menus.
-- [ ] Custom depth buttons - dynamic depth if undefined.
-- [X] Labels for input buttons in popup menus.
-- [ ] Status templates in the extension settings menu.
-- [ ] Turn entries into global entries.
-
 ## Installation
-Install the extension using this link: ```https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git```
+Install the extension using this link inside SillyTavern's extensions installer: ```https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git```
 
-### Compatibility
-- This extension might not work with **kaldigo**'s Tracker.
-- The same as above with **cierru**'s Stepped Thinking.
-Is not that it **won't** because it probably does work, but the UI might get cluttered (I don't use those extensions and this was not tested with their UIs). Please, let me know if this work with those extensions to remove this warning.
+### Support and Contributions
+- My to-do list is overflowing, feel free to submit a PR with the feature you want! Make sure to read the **Contribution Rules**, as long as you follow them, any change you update will be accepted (if it's reasonable).
 
-## Support and Contributions
-- My to-do list is overflowing, feel free to submit a PR with the feature you want! Make sure to read the **Contribution Rules**.
-
-## Contribution Rules
+### Contribution Rules
 - Always PR to the `staging` branch.
-- Use the `staging` branch as the source of you working branch.
+- Use the `staging` branch as the source of you working branch. If you create a new branch to work on your feature, make sure you use the `staging` branch as the source of the new branch.
 - Nothing else really, enjoy.

--- a/index.js
+++ b/index.js
@@ -571,10 +571,14 @@ function addTracker(status, character) {
             const step = Number(props[2]) <= 0 ? 1 : props[2];
             const value = props[3];
             const input = `
-                <span class="d-flex flex-col flex-center gap-0 type-range chat-input-editor">
-                    <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-slider" id="${characterName}-${entry_uid}-${inputID}" />
-                    <input type="number" min="${min}" max="${max}" step="${step}" value="${value}" class="neo-range-input" data-for="${characterName}-${entry_uid}-${inputID}" id="counter-${characterName}-${entry_uid}-${inputID}" />
+                <span class="text-quote" id="${characterName}-${entry_uid}-${inputID}-display">
+                    <span class="value font-monospace">${value}</span>
+                    <span class="d-inline-flex gap-0 text-body cursor-pointer fs-normal">
+                        <span class="fa-solid fa-caret-left m-0 chat-input-icon select-none opacity-60"></span>
+                        <span class="fa-solid fa-caret-right m-0 chat-input-icon select-none"></span>
+                    </span>
                 </span>
+                <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="type-range chat-input-editor" id="${characterName}-${entry_uid}-${inputID}" />
             `;
 
             inputID++;
@@ -600,7 +604,7 @@ function addTracker(status, character) {
             let newMacro = "";
 
             if (chunk instanceof HTMLSpanElement) {
-                /**@type {HTMLInputElement}*/const inputNumber = chunk.querySelector('input[type="number"]');
+                /**@type {HTMLInputElement}*/const inputNumber = chunk.querySelector('input[type="range"]');
                 const min = inputNumber.min;
                 const max = inputNumber.max;
                 const step = inputNumber.step;
@@ -815,20 +819,65 @@ function addTracker(status, character) {
 
             el(newRow, el_target)
             .querySelectorAll('.chat-input-editor.type-range')
-            .forEach((/**@type {HTMLSpanElement}*/span) => {
-                /**@type {HTMLInputElement}*/const inputNumber = span.querySelector('input[type="number"]');
-                /**@type {HTMLInputElement}*/const inputRange = span.querySelector('input[type="range"]');
+            .forEach((/**@type {HTMLInputElement}*/inputRange) => {
+                /**@type {HTMLSpanElement}*/const fakeInput = inputRange.parentElement.querySelector(`#${inputRange.id}-display .value`);
 
-                span.addEventListener("input", (e) => {
+                inputRange.addEventListener("input", function(e) {
                     /**@type {HTMLInputElement}*/
                     // @ts-ignore
                     const original = e.target;
-                    inputNumber.value = original.value;
-                    inputRange.value = original.value;
+                    fakeInput.textContent = original.value;
 
                     el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
                     dispatchInput(form);
                 }, {passive: true});
+
+                inputRange.addEventListener("keypress", function(e) {
+                    const { key } = e;
+
+                    if (!["ArrowUp", "ArrowDown"].includes(key)) return;
+
+                    const nextInc = Number(inputRange.step);
+                    const min = Number(inputRange.min);
+                    const max = Number(inputRange.max);
+                    let direction = 1;
+
+                    if (key === "ArrowDown") direction = -1;
+
+                    const currentValue = Number(inputRange.value);
+                    const nextValue = currentValue + (nextInc * direction);
+
+                    if (nextValue < min) inputRange.value = min;
+                    else if (nextValue > max) inputRange.value = max;
+                    else inputRange.value = nextValue;
+
+                    dispatchInput(inputRange);
+                });
+
+                inputRange.addEventListener("wheel", async (e) => {
+                    if (!inputRange.matches(':focus')) return;
+
+                    if (e.cancelable) e.preventDefault();
+
+                    const nextInc = Number(inputRange.step);
+                    const min = Number(inputRange.min);
+                    const max = Number(inputRange.max);
+                    let direction = 1;
+
+                    if (e.deltaY === 0) return;
+                    if (e.deltaY > 0) direction = -1; // Wheel down
+
+                    const currentValue = Number(inputRange.value);
+                    const nextValue = currentValue + (nextInc * direction);
+
+                    if (nextValue < min) inputRange.value = min;
+                    else if (nextValue > max) inputRange.value = max;
+                    else inputRange.value = nextValue;
+
+                    dispatchInput(inputRange);
+                }, {passive: false});
+
+                fakeInput.addEventListener("click", () => inputRange.focus());
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -1103,7 +1103,9 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
             if (entry.key !== "" && value !== "") promptValue += entry.separator;
 
             promptValue += value
-                .replaceAll(/\/\/.*(\n|$)/g, "$1");
+                .replaceAll(/\/\/.*(?=\}\})/g, "")
+                .replaceAll(/\/\/.*(?=\n)/g, "")
+                .replaceAll(/\/\/.*(?=$)/g, "");
         };
 
         if (!promptValue) continue;

--- a/index.js
+++ b/index.js
@@ -336,6 +336,8 @@ function renderCaret(span, text, caretPos, selectEnd = caretPos) {
 
     destroyElement(span.childNodes);
 
+    if (!text) span.setAttribute('data-empty', '');
+    else span.removeAttribute('data-empty');
     if (caretPos < 0) return span.textContent = text;
 
     const before = esc(text.slice(0, caretPos));
@@ -523,9 +525,8 @@ function addTracker(status, character) {
         newText = newText.replaceAll(regexTextInput, (match) => {
             const value = match.replaceAll(/((^{{text(::)?)|(}}$))/g, "").replaceAll("<br>", "\n");
             const input = `
-                <span class="fa-solid fa-t m-0 chat-input-icon focus-button select-none cursor-pointer"></span>
                 <textarea type="text" class="type-text fake-input chat-input-editor mw-unset" data-pattern="^[^{}]*$" autocomplete="off" data-stee--handled="1" tabindex="-1">${value}</textarea>
-                <span class="text-quote"><span class="value ${extensionSettings.showWhiteSpaces ? "show-spaces" : ""}">${value}</span></span>
+                <span class="text-quote"><span class="value ${extensionSettings.showWhiteSpaces ? 'show-spaces' : ''}" ${!value ? 'data-empty' : ''}>${value}</span></span>
             `;
 
             inputID++;
@@ -535,7 +536,6 @@ function addTracker(status, character) {
         newText = newText.replaceAll(regexNumberInput, (match) => {
             const value = match.replaceAll(/(({{number(::)?)|(}}))/g, "");
             const input = `
-                <span class="fa-solid fa-n m-0 chat-input-icon focus-button select-none cursor-pointer"></span>
                 <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" data-pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0" />
                 <span class="text-quote">
                     <span class="value font-monospace">${value}</span>
@@ -708,77 +708,74 @@ function addTracker(status, character) {
                         dispatchInput(form);
                     }, {passive: true});
                 } else {
-                    const eventTargets = [input.nextElementSibling, input.previousElementSibling];
+                    /**@type {HTMLSpanElement} */
+                    const spanInput = input.nextElementSibling;
                     let lastValid = input.value;
                     let inputTimeout;
+                    let spanSelected = false;
+                    let incrementsPressed;
+                    let incrementsCooldown;
 
-                    eventTargets.forEach((/**@type {HTMLSpanElement} */span) => {
-                        let spanSelected = false;
-                        let incrementsPressed;
-                        let incrementsCooldown;
+                    spanInput.addEventListener("pointerdown", (e) => {
+                        if (spanSelected) return;
 
-                        span.addEventListener("pointerdown", (e) => {
-                            if (spanSelected) return;
+                        spanSelected = true;
+                    }, {passive: true});
 
-                            spanSelected = true;
+                    document.addEventListener("click", (e) => {
+                        clearInterval(incrementsPressed);
+                        clearTimeout(incrementsCooldown);
+
+                        if (!spanSelected) return;
+
+                        spanSelected = false;
+                        let selection;
+
+                        selection = getSelectedTextInElem(spanInput.querySelector('.value'));
+
+                        input.setSelectionRange(selection.start, selection.end);
+                        input.focus();
+                    }, {passive: true});
+
+                    if (input.classList.contains("type-number") && spanInput.classList.contains("text-quote")) {
+                        const arrowDown = new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: false, cancelable: true});
+                        const arrowUp = new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: false, cancelable: true});
+
+                        spanInput.addEventListener("wheel", async (e) => {
+                            if (!input.matches(':focus')) return;
+
+                            if (e.cancelable) e.preventDefault();
+
+                            let direction;
+
+                            if (e.deltaY === 0) return;
+                            if (e.deltaY < 0) direction = arrowUp;
+                            if (e.deltaY > 0) direction = arrowDown;
+
+                            setTimeout(() => input.dispatchEvent(direction), 10);
+                        }, {passive: false});
+
+                        /**@type {HTMLSpanElement}*/const minusButton = spanInput.querySelector('.fa-caret-left');
+                        /**@type {HTMLSpanElement}*/const plusButton = spanInput.querySelector('.fa-caret-right');
+
+                        minusButton.addEventListener("pointerdown", (e) => {
+                            if (e.button === 2) return;
+
+                            input.dispatchEvent(arrowDown);
+                            incrementsCooldown = setTimeout(() => {
+                                incrementsPressed = setInterval(() => input.dispatchEvent(arrowDown), 75);
+                            }, 300);
                         }, {passive: true});
 
-                        document.addEventListener("click", (e) => {
-                            clearInterval(incrementsPressed);
-                            clearTimeout(incrementsCooldown);
+                        plusButton.addEventListener("pointerdown", (e) => {
+                            if (e.button === 2) return;
 
-                            if (!spanSelected) return;
-
-                            spanSelected = false;
-                            let selection;
-
-                            if (span.classList.contains("chat-input-icon")) selection = {start: input.value.length, end: input.value.length};
-                            else selection = getSelectedTextInElem(span.querySelector('.value'));
-
-                            input.setSelectionRange(selection.start, selection.end);
-                            input.focus();
+                            input.dispatchEvent(arrowUp);
+                            incrementsCooldown = setTimeout(() => {
+                                incrementsPressed = setInterval(() => input.dispatchEvent(arrowUp), 75);
+                            }, 300);
                         }, {passive: true});
-
-                        if (input.classList.contains("type-number") && span.classList.contains("text-quote")) {
-                            const arrowDown = new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: false, cancelable: true});
-                            const arrowUp = new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: false, cancelable: true});
-
-                            span.addEventListener("wheel", async (e) => {
-                                if (!input.matches(':focus')) return;
-
-                                if (e.cancelable) e.preventDefault();
-
-                                let direction;
-
-                                if (e.deltaY === 0) return;
-                                if (e.deltaY < 0) direction = arrowUp;
-                                if (e.deltaY > 0) direction = arrowDown;
-
-                                setTimeout(() => input.dispatchEvent(direction), 10);
-                            }, {passive: false});
-
-                            /**@type {HTMLSpanElement}*/const minusButton = span.querySelector('.fa-caret-left');
-                            /**@type {HTMLSpanElement}*/const plusButton = span.querySelector('.fa-caret-right');
-
-                            minusButton.addEventListener("pointerdown", (e) => {
-                                if (e.button === 2) return;
-
-                                input.dispatchEvent(arrowDown);
-                                incrementsCooldown = setTimeout(() => {
-                                    incrementsPressed = setInterval(() => input.dispatchEvent(arrowDown), 75);
-                                }, 300);
-                            }, {passive: true});
-
-                            plusButton.addEventListener("pointerdown", (e) => {
-                                if (e.button === 2) return;
-
-                                input.dispatchEvent(arrowUp);
-                                incrementsCooldown = setTimeout(() => {
-                                    incrementsPressed = setInterval(() => input.dispatchEvent(arrowUp), 75);
-                                }, 300);
-                            }, {passive: true});
-                        }
-                    });
+                    }
 
                     input.addEventListener("input", () => {
                         if (input.dataset.pattern) {

--- a/index.js
+++ b/index.js
@@ -523,7 +523,7 @@ function addTracker(status, character) {
         newText = newText.replaceAll(regexTextInput, (match) => {
             const value = match.replaceAll(/((^{{text(::)?)|(}}$))/g, "").replaceAll("<br>", "\n");
             const input = `
-                <span class="fa-solid fa-t m-0 chat-input-icon select-none cursor-pointer"></span>
+                <span class="fa-solid fa-t m-0 chat-input-icon focus-button select-none cursor-pointer"></span>
                 <textarea type="text" class="type-text fake-input chat-input-editor mw-unset" data-pattern="^[^{}]*$" autocomplete="off" data-stee--handled="1" tabindex="-1">${value}</textarea>
                 <span class="text-quote"><span class="value ${extensionSettings.showWhiteSpaces ? "show-spaces" : ""}">${value}</span></span>
             `;
@@ -535,7 +535,7 @@ function addTracker(status, character) {
         newText = newText.replaceAll(regexNumberInput, (match) => {
             const value = match.replaceAll(/(({{number(::)?)|(}}))/g, "");
             const input = `
-                <span class="fa-solid fa-n m-0 chat-input-icon select-none cursor-pointer"></span>
+                <span class="fa-solid fa-n m-0 chat-input-icon focus-button select-none cursor-pointer"></span>
                 <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" data-pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0" />
                 <span class="text-quote">
                     <span class="value font-monospace">${value}</span>
@@ -573,6 +573,10 @@ function addTracker(status, character) {
             const input = `
                 <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="type-range chat-input-editor" id="${characterName}-${entry_uid}-${inputID}" />
                 <span class="text-quote" id="${characterName}-${entry_uid}-${inputID}-display">
+                    <span class="d-inline-flex gap-0 text-body input-arrows cursor-pointer fs-normal">
+                        <span class="fa-solid fa-caret-left m-0 chat-input-icon select-none opacity-60" data-direction="-1"></span>
+                        <span class="fa-solid fa-caret-right m-0 chat-input-icon select-none" data-direction="1"></span>
+                    </span>
                     <span class="value font-monospace">${value}</span>
                 </span>
             `;
@@ -816,6 +820,7 @@ function addTracker(status, character) {
             .querySelectorAll('.chat-input-editor.type-range')
             .forEach((/**@type {HTMLInputElement}*/inputRange) => {
                 /**@type {HTMLSpanElement}*/const fakeInput = inputRange.parentElement.querySelector(`#${inputRange.id}-display .value`);
+                /**@type {HTMLSpanElement}*/const inputArrows = inputRange.parentElement.querySelector(`#${inputRange.id}-display .input-arrows`);
 
                 const updateInput = function() {
                     fakeInput.textContent = inputRange.value;
@@ -860,6 +865,24 @@ function addTracker(status, character) {
 
                     if (e.deltaY === 0) return;
                     if (e.deltaY > 0) direction = -1; // Wheel down
+
+                    const currentValue = Number(inputRange.value);
+                    const nextValue = currentValue + (nextInc * direction);
+
+                    if (nextValue < min) inputRange.value = min;
+                    else if (nextValue > max) inputRange.value = max;
+                    else inputRange.value = nextValue;
+
+                    updateInput();
+                }, {passive: false});
+
+                inputArrows.addEventListener("click", function(e) {
+                    inputRange.focus();
+
+                    const direction = e.target.dataset.direction;
+                    const nextInc = Number(inputRange.step);
+                    const min = Number(inputRange.min);
+                    const max = Number(inputRange.max);
 
                     const currentValue = Number(inputRange.value);
                     const nextValue = currentValue + (nextInc * direction);

--- a/index.js
+++ b/index.js
@@ -437,6 +437,7 @@ function addTracker(status, character) {
                         <span class="stat-us-max-chat-title">${character.name}</span>
                     </span>
                     <div class="d-flex flex-center">
+                        <div class="menu_button menu_button_icon fa-solid fa-arrows-rotate interactable m-0 px-10px" title="Refresh the block display and macros" data-i18n="[title]Refresh the block display and macros"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-floppy-disk interactable m-0 px-10px" title="Force Status metadata to save" data-i18n="[title]Force Status metadata to save"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-eye interactable m-0"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-pen interactable m-0"></div>
@@ -485,6 +486,10 @@ function addTracker(status, character) {
     statusTable.querySelector(".menu_button.fa-floppy-disk").addEventListener("click", async function () {
         setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
+    }, { passive: true });
+
+    statusTable.querySelector(".menu_button.fa-arrows-rotate").addEventListener("click", async function () {
+        addTracker(status, character);
     }, { passive: true });
 
     statusTable.querySelector(".menu_button.fa-pen").addEventListener("click", async function () {

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ const defaultSettings = {
     minPromptDepth: 0,
     alwaysIncludeUnmutedMembers: false,
     altMacroTemplateBehavior: false,
+    autoSaveMetadata: true,
     debug: false
 };
 
@@ -427,6 +428,7 @@ function addTracker(status, character) {
                         <span class="stat-us-max-chat-title">${character.name}</span>
                     </span>
                     <div class="d-flex flex-center">
+                        <div class="menu_button menu_button_icon fa-solid fa-floppy-disk interactable m-0"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-eye interactable m-0"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-pen interactable m-0"></div>
                     </div>
@@ -471,7 +473,11 @@ function addTracker(status, character) {
         el.classList.toggle("d-none", state);
     };
 
-    statusTable.querySelector(".menu_button.fa-pen").addEventListener("click", async () => {
+    statusTable.querySelector(".menu_button.fa-floppy-disk").addEventListener("click", async function () {
+        SillyTavern.getContext().saveChat();
+    }, { passive: true });
+
+    statusTable.querySelector(".menu_button.fa-pen").addEventListener("click", async function () {
         const metadata = chat_metadata.stat_us_maximus;
 
         // @ts-ignore
@@ -480,12 +486,12 @@ function addTracker(status, character) {
         return await popupStatusSingleChar(character);
     }, {passive: true});
 
-    statusTable.querySelector(".menu_button.fa-eye").addEventListener("click", async () => {
+    statusTable.querySelector(".menu_button.fa-eye").addEventListener("click", async function () {
         const collapse = !statusTableBody.classList.contains("d-none");
         status.is_collapsed = collapse;
 
         toggleVisibility(statusTableBody, collapse);
-        SillyTavern.getContext().saveMetadataDebounced();
+        if (extensionSettings.autoSaveMetadata) SillyTavern.getContext().saveChat();
     }, {passive: true});
 
     const createInputs = (/**@type {String}*/text, entry_uid) => {
@@ -819,7 +825,7 @@ function addTracker(status, character) {
 
             const formData = new FormData(form);
 
-            updateCharEntry(character, entry.uid, formData);
+            updateCharEntry(character, entry.uid, formData, extensionSettings.autoSaveMetadata);
         }, { passive: false });
 
         form.addEventListener("input", () => {
@@ -1098,7 +1104,7 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
         );
     }
 
-    SillyTavern.getContext().saveMetadataDebounced();
+    if (extensionSettings.autoSaveMetadata) SillyTavern.getContext().saveChat();
 }
 
 /**
@@ -1232,6 +1238,7 @@ function settingsNumberButton(event) {
 function displaySettings() {
     console.debug("[" + extensionName + "]", `Auto detect participants is ${extensionSettings.autoDetectParticipants ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", `Always include unmuted group members is ${extensionSettings.alwaysIncludeUnmutedMembers ? "active" : "not active"}`);
+    console.debug("[" + extensionName + "]", `Auto save metadata is ${extensionSettings.autoSaveMetadata ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", `Alternative behavior for macro template buttons is ${extensionSettings.altMacroTemplateBehavior ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", `Show input macros in chat is ${extensionSettings.editNumbersFromChat ? "active" : "not active"}`);
     console.debug("[" + extensionName + "]", `Hide input labels is ${extensionSettings.hideInputLabels ? "active" : "not active"}`);
@@ -1251,6 +1258,7 @@ async function loadHTMLSettings() {
     // Event Listeners for the extension HTML
     $("#stat-us-max-auto-detect-participants").on("input", settingsBooleanButton);
     $("#stat-us-max-always-include-unmuted-members").on("input", settingsBooleanButton);
+    $("#stat-us-max-auto-save-metadata").on("input", settingsBooleanButton);
     $("#stat-us-max-alt-macro-template-behavior").on("input", settingsBooleanButton);
     $("#stat-us-max-show-input-macros").on("input", settingsBooleanButton);
     $("#stat-us-max-hide-input-labels").on("input", settingsBooleanButton);
@@ -1267,6 +1275,7 @@ async function loadHTMLSettings() {
 function setSettings() {
     $("#stat-us-max-auto-detect-participants").prop("checked", extensionSettings.autoDetectParticipants);
     $("#stat-us-max-always-include-unmuted-members").prop("checked", extensionSettings.alwaysIncludeUnmutedMembers);
+    $("#stat-us-max-auto-save-metadata").prop("checked", extensionSettings.autoSaveMetadata);
     $("#stat-us-max-alt-macro-template-behavior").prop("checked", extensionSettings.altMacroTemplateBehavior);
     $("#stat-us-max-show-input-macros").prop("checked", extensionSettings.editNumbersFromChat);
     $("#stat-us-max-show-white-spaces").prop("checked", extensionSettings.showWhiteSpaces);

--- a/index.js
+++ b/index.js
@@ -538,7 +538,7 @@ function addTracker(status, character) {
             const input = `
                 <input type="text" value="${value === "" ? "0" : value}" inputmode="decimal" autocomplete="off" data-pattern="^-?\\d+\\.?\\d*$" class="type-number fake-input chat-input-editor" size="0" />
                 <span class="text-quote">
-                    <span class="value font-monospace">${value}</span>
+                    <span class="value font-monospace">${value === "" ? "0" : value}</span>
                     <span class="d-inline-flex gap-0 text-body cursor-pointer fs-normal">
                         <span class="fa-solid fa-caret-left m-0 chat-input-icon select-none opacity-60"></span>
                         <span class="fa-solid fa-caret-right m-0 chat-input-icon select-none"></span>

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import { lodash, Popper } from "../../../../lib.js";
 /*  # TODO
     - [ ] Setting to disable confirm delete
     - [ ] Setting for deff role
+    - [ ] Rearrange range input into a more compact layout - input[number] [space] input[range|fat]
     - [X] Setting to disable auto detection
     - [X] Replace select button for an icon button
     - [X] Highlight row on hover
@@ -21,19 +22,46 @@ import { lodash, Popper } from "../../../../lib.js";
     - [X] Reduce font-size
     - [X] Button on right nav panel to open user metadata - one for active and another for all
     - [X] Use alt title if description is empty
-    - [ ] Global Stat not attached to character
     - [X] Fix chat UI select button using a similar approach to character export button - thanks Ross
 
-    - [ ] Before I loose the idea - Update chat UI on input input, this would allow sick tricks like modifying a variable value from an input inside the set var macro - That would require
-        - [ ] Parsing ST variables on input (and parsing mine's first)
-        - [ ] Figure out how to update the UI without loosing focus of the input (maybe when the input looses focus?)
-
-    I need to refine this roadmap
-    - [ ] Create a template builder ? from the settings
-        - [ ] Store it in ? extension settings as an array
-        - [ ] Allow to bind templates to both characters and groups (group overrides character)
-        - [ ] ? Merge group and character templates
-        - [ ] ? Allow to assign multiple templates
+    I hate it, but a rewrite is needed, this code is a headache to maintain
+    (TODO once the main TODO of this file is finished)
+    - [ ] Rewrite code using classes
+        - [ ] ChatInputMacro
+        - [ ] StumMacroParser
+            - macroToInput
+            - inputToMacro
+            - parseCoreMacros
+            - parseStumMacros
+            - parseThirdPartyMacros
+            - parseAllMacros
+        - [ ] StatUs // from statusControls.js
+            - assignCharacter // this would allow applying templates
+            - assignChat // this would allow chat templates
+            - assignGlobal // this would allow constantly active templates
+        - [ ] StatUsEntry // from statusControls.js
+        - [ ] TemplateBuilder<StatUs>
+            - getTemplate
+            - createFromSettings
+            - createFromClipboard
+            - applyToClipboard
+        - [ ] StumSlashCommand
+            - registerCommand
+            - validateInputArguments
+            - createFormData
+        - [ ] StatUsPopupBlock
+        - [ ] StatUsChatBlock
+            - runScript ? I would like to continue the idea of triggering scripts by typing in the inputs/switching alt values/disabling and enabling
+        - [ ] StatUsButtonsBlock
+        - [ ] Utilities
+            - debounceFunction //Debounce Func with unique IDs
+            - addHtmlTemplate ? This or create on class instance
+            - getHtmlTemplate
+        - [ ] ExtensionSettings
+    - [ ] Rewrite code using HTML templates
+        - [ ] statUsChatBlock
+        - [ ] statUsPopupBlock
+        - [ ] statUsButtonsBlock
 
     ! THE PLAN
 
@@ -1248,7 +1276,7 @@ function setSettings() {
     $("#stat-us-max-debug").prop("checked", extensionSettings.debug).trigger("input");
 }
 
-// * MARK:Initialize Extension
+// * MARK:Initialize Buttons
 
 function initButtons() {
     /** Magic wand menu */

--- a/index.js
+++ b/index.js
@@ -140,6 +140,15 @@ export function destroyElement(element) {
 	elem.remove();
 }
 
+/**
+ * @param {boolean} state
+ */
+export function setSaveStateFlag(state) {
+    const nextState = state ? "transparent" : "red";
+
+    document.documentElement.style.setProperty('--stum-save-state-color', nextState);
+}
+
 function getCharacter(value, search_key = "avatar") {
     return characters.find(c => c[search_key] === value) ?? false;
 }
@@ -405,13 +414,13 @@ function addTracker(status, character) {
                 <input type="hidden" name="value_uid">
             </form>
             <div class="d-flex flex-center-between gap-15px fs-90p text-muted hover-highlight">
-                <div class="fa-solid fa-toggle-on kill-switch" title="Toggle entry's active state" data-i18n="Toggle entry's active state"></div>
+                <div class="fa-solid fa-toggle-on kill-switch" title="Toggle entry's active state" data-i18n="[title]Toggle entry's active state"></div>
                 <p class="text-left flex-grow-1 m-0 d-table">
                     <span class="status-title fw-bolder d-contents"></span>
                     <span class="status-separator"></span>
                     <span class="status-description d-contents"></span>
                 </p>
-                <div class="status-value-uid fa-solid fa-bars-progress m-0" aria-describedby="tooltip" title="Swap entry description" data-i18n="Swap entry description"></div>
+                <div class="status-value-uid fa-solid fa-bars-progress m-0" aria-describedby="tooltip" title="Swap entry description" data-i18n="[title]Swap entry description"></div>
             </div>
         </td>
     `;
@@ -428,7 +437,7 @@ function addTracker(status, character) {
                         <span class="stat-us-max-chat-title">${character.name}</span>
                     </span>
                     <div class="d-flex flex-center">
-                        <div class="menu_button menu_button_icon fa-solid fa-floppy-disk interactable m-0"></div>
+                        <div class="menu_button menu_button_icon fa-solid fa-floppy-disk interactable m-0 px-10px" title="Force Status metadata to save" data-i18n="[title]Force Status metadata to save"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-eye interactable m-0"></div>
                         <div class="menu_button menu_button_icon fa-solid fa-pen interactable m-0"></div>
                     </div>
@@ -474,6 +483,7 @@ function addTracker(status, character) {
     };
 
     statusTable.querySelector(".menu_button.fa-floppy-disk").addEventListener("click", async function () {
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
     }, { passive: true });
 
@@ -491,6 +501,7 @@ function addTracker(status, character) {
         status.is_collapsed = collapse;
 
         toggleVisibility(statusTableBody, collapse);
+        setSaveStateFlag(extensionSettings.autoSaveMetadata);
         if (extensionSettings.autoSaveMetadata) SillyTavern.getContext().saveChat();
     }, {passive: true});
 
@@ -825,6 +836,7 @@ function addTracker(status, character) {
 
             const formData = new FormData(form);
 
+            setSaveStateFlag(extensionSettings.autoSaveMetadata);
             updateCharEntry(character, entry.uid, formData, extensionSettings.autoSaveMetadata);
         }, { passive: false });
 
@@ -1103,8 +1115,6 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
             status.role
         );
     }
-
-    if (extensionSettings.autoSaveMetadata) SillyTavern.getContext().saveChat();
 }
 
 /**
@@ -1306,7 +1316,7 @@ function initButtons() {
     globalStatusMenu.id = extensionName.toLowerCase().replace("-", "_") + "_wand_container";
     globalStatusMenu.classList.add("extension_container", "interactable");
     globalStatusMenu.append(globalStatusButton);
-    globalStatusMenu.addEventListener("click", async () => {
+    globalStatusMenu.addEventListener("click", async function () {
         const metadata = chat_metadata.stat_us_maximus;
         const chars = [];
 
@@ -1331,11 +1341,20 @@ function initButtons() {
     charStatusSpan.dataset.i18n = "Stat-us Maximus";
     charStatusSpan.classList.add("flex-grow-1");
 
+    const saveStatusDataBtn = document.createElement("div");
+    saveStatusDataBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-floppy-disk", "interactable", "m-0", "px-10px");
+    saveStatusDataBtn.title = "Force Status metadata to save";
+    saveStatusDataBtn.dataset.i18n = "Force Status metadata to save";
+    saveStatusDataBtn.addEventListener("click", async function () {
+        setSaveStateFlag(true);
+        SillyTavern.getContext().saveChat();
+    }, { passive: true });
+
     const personasStatusOpenPopupBtn = document.createElement("div");
     personasStatusOpenPopupBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-users-cog", "interactable", "m-0");
     personasStatusOpenPopupBtn.title = "Open status for all the personas with status";
     personasStatusOpenPopupBtn.dataset.i18n = "Open status for all the personas with status";
-    personasStatusOpenPopupBtn.addEventListener("click", async () => {
+    personasStatusOpenPopupBtn.addEventListener("click", async function () {
         const metadata = chat_metadata.stat_us_maximus.filter(s => s.is_user);
         const users = [];
 
@@ -1355,7 +1374,7 @@ function initButtons() {
     personaStatusOpenPopupBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-user-cog", "interactable", "m-0");
     personaStatusOpenPopupBtn.title = "Open status for the active persona";
     personaStatusOpenPopupBtn.dataset.i18n = "Open status for the active persona";
-    personaStatusOpenPopupBtn.addEventListener("click", async () => {
+    personaStatusOpenPopupBtn.addEventListener("click", async function () {
         const user = getUser();
 
         // @ts-ignore
@@ -1368,7 +1387,7 @@ function initButtons() {
     charStatusOpenPopupBtn.classList.add("menu_button", "menu_button_icon", "fa-solid", "fa-table", "interactable", "m-0");
     charStatusOpenPopupBtn.title = "Open status for the active character";
     charStatusOpenPopupBtn.dataset.i18n = "Open status for the active character";
-    charStatusOpenPopupBtn.addEventListener("click", async () => {
+    charStatusOpenPopupBtn.addEventListener("click", async function () {
         // @ts-ignore
         if (this_chid === undefined) return toastr.warning(t`An active character to edit could not be found`);
 
@@ -1382,7 +1401,7 @@ function initButtons() {
 
     const charStatusMenu = document.createElement("div");
     charStatusMenu.classList.add("d-flex", "flex-center-start", "gap-5px", "standoutHeader", "p-5px");
-    charStatusMenu.append(charStatusSpan, charStatusOpenPopupBtn, personaStatusOpenPopupBtn, personasStatusOpenPopupBtn);
+    charStatusMenu.append(charStatusSpan, saveStatusDataBtn, charStatusOpenPopupBtn, personaStatusOpenPopupBtn, personasStatusOpenPopupBtn);
 
     const charStatusContainer = document.createElement("div");
     charStatusContainer.classList.add("stat-us-max-custom-css");
@@ -1398,8 +1417,14 @@ function initButtons() {
     groupStatusContainer.firstElementChild.classList.add("border", "border-faded");
     groupStatusContainer.firstElementChild.classList.remove("separator-bottom");
 
+    const groupSaveStatusDataBtn = groupStatusContainer.querySelector('.menu_button.fa-floppy-disk');
+    groupSaveStatusDataBtn.addEventListener("click", function () {
+        setSaveStateFlag(true);
+        SillyTavern.getContext().saveChat();
+    }, { passive: true });
+
     const groupPersonasBtn = groupStatusContainer.querySelector('.menu_button.fa-users-cog');
-    groupPersonasBtn.addEventListener("click", async () => {
+    groupPersonasBtn.addEventListener("click", async function () {
         const metadata = chat_metadata.stat_us_maximus.filter(s => s.is_user);
         const users = [];
 
@@ -1416,7 +1441,7 @@ function initButtons() {
     }, {passive: true});
 
     const groupPersonaBtn = groupStatusContainer.querySelector('.menu_button.fa-user-cog');
-    groupPersonaBtn.addEventListener("click", async () => {
+    groupPersonaBtn.addEventListener("click", async function () {
         const user = getUser();
 
         // @ts-ignore
@@ -1428,7 +1453,7 @@ function initButtons() {
     /** @type {HTMLElement} */const groupMembersButton = groupStatusContainer.querySelector('.menu_button.fa-table');
     groupMembersButton.title = "Open status for all group members";
     groupMembersButton.dataset.i18n = "Open status for all group members";
-    groupMembersButton.addEventListener("click", async () => {
+    groupMembersButton.addEventListener("click", async function () {
         const chars = getActiveParticipants([{avatar: user_avatar}]);
 
         // @ts-ignore

--- a/index.js
+++ b/index.js
@@ -571,14 +571,10 @@ function addTracker(status, character) {
             const step = Number(props[2]) <= 0 ? 1 : props[2];
             const value = props[3];
             const input = `
+                <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="type-range chat-input-editor" id="${characterName}-${entry_uid}-${inputID}" />
                 <span class="text-quote" id="${characterName}-${entry_uid}-${inputID}-display">
                     <span class="value font-monospace">${value}</span>
-                    <span class="d-inline-flex gap-0 text-body cursor-pointer fs-normal">
-                        <span class="fa-solid fa-caret-left m-0 chat-input-icon select-none opacity-60"></span>
-                        <span class="fa-solid fa-caret-right m-0 chat-input-icon select-none"></span>
-                    </span>
                 </span>
-                <input type="range" min="${min}" max="${max}" step="${step}" value="${value}" class="type-range chat-input-editor" id="${characterName}-${entry_uid}-${inputID}" />
             `;
 
             inputID++;

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ export function destroyElement(element) {
  * @param {boolean} state
  */
 export function setSaveStateFlag(state) {
-    const nextState = state ? "transparent" : "red";
+    const nextState = state ? "var(--SmartThemeBlurTintColor)" : "red";
 
     document.documentElement.style.setProperty('--stum-save-state-color', nextState);
 }
@@ -1157,19 +1157,19 @@ const settingsCallbacks = {
     rangeInputWidthTimeout: undefined,
 
     /**	Triggers on editNumbersFromChat change. */
-    editNumbersFromChat: () => {
+    editNumbersFromChat: function () {
         fetchStatus({forceUIUpdate: true});
     },
 
     /**	Triggers on hideInputLabels change. */
-    hideInputLabels: () => {
+    hideInputLabels: function () {
         const newDisplay = extensionSettings.hideInputLabels ? 'none' : 'block';
 
         document.documentElement.style.setProperty('--stum-input-label-display', newDisplay);
     },
 
     /**	Triggers on rangeInputWidth change. */
-    rangeInputWidth: () => {
+    rangeInputWidth: function () {
         clearTimeout(settingsCallbacks.rangeInputWidthTimeout);
 
         const newWidth = String($("#stat-us-max-range-input-width").val());
@@ -1180,12 +1180,20 @@ const settingsCallbacks = {
     },
 
     /**	Triggers on showWhiteSpaces change. */
-    showWhiteSpaces: () => {
+    showWhiteSpaces: function () {
         document
         .querySelectorAll('#chat .stat-us-max-custom-css .text-quote .value')
         .forEach((/**@type {HTMLSpanElement}*/span) =>
             span.classList.toggle("show-spaces", extensionSettings.showWhiteSpaces)
         );
+    },
+
+    /**	Triggers on autoSaveMetadata change. */
+    autoSaveMetadata: function () {
+        if (extensionSettings.autoSaveMetadata) {
+            setSaveStateFlag(true);
+            SillyTavern.getContext().saveChat();
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import { extension_settings } from "../../../extensions.js";
 import { saveSettingsDebounced, chat_metadata, this_chid, chat, characters, extension_prompts, setExtensionPrompt, extension_prompt_types, user_avatar, substituteParams } from "../../../../script.js";
 import { getGroupMembers, groups, selected_group } from "../../../group-chats.js";
 import { t } from "../../../i18n.js";
-import { createCharStatus, getCharAltValue, getCharStatus, saveMetadataSTUM, updateCharEntry } from "./source/js/statusControls.js";
+import { createCharStatus, getCharAltValue, getCharStatus, updateCharEntry } from "./source/js/statusControls.js";
 import { power_user } from "../../../power-user.js";
 import { registerSlashCommands } from "./source/js/slashCommands.js";
 import { popupStatusMultiChar, popupStatusSingleChar } from "./source/js/popups.js";
@@ -485,7 +485,7 @@ function addTracker(status, character) {
         status.is_collapsed = collapse;
 
         toggleVisibility(statusTableBody, collapse);
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
     }, {passive: true});
 
     const createInputs = (/**@type {String}*/text, entry_uid) => {
@@ -1098,7 +1098,7 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
         );
     }
 
-    saveMetadataSTUM();
+    SillyTavern.getContext().saveMetadataDebounced();
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -511,7 +511,7 @@ function addTracker(status, character) {
     }, {passive: true});
 
     const createInputs = (/**@type {String}*/text, entry_uid) => {
-        const parsedText = lodash.escape(substituteParams(processMacros(text, {char: character, processInputs: false}))).replaceAll(/\n/g, "<br>");
+        const parsedText = lodash.escape(processMacros(text, {char: character, processInputs: false, removeComments: false})).replaceAll(/\n/g, "<br>");
 
         if (!extensionSettings.editNumbersFromChat)
             return `<span class="text-line">${parsedText}</span>`;
@@ -965,7 +965,18 @@ function addTracker(status, character) {
     toggleVisibility(statusTableBody, status.is_collapsed ?? false);
 }
 
-export function processMacros(text, {char = undefined, processInputs = true} = {}) {
+
+/**
+ * Replaces macros in the given text with their corresponding values.
+ * @param {string} text
+ * @param {object} options
+ * @param {object} options.char
+ * @param {boolean} options.processInputs
+ * @param {boolean} options.removeComments
+ * @param {boolean} options.replaceAppMacros
+ * @returns {string}
+ */
+export function processMacros(text = '', {char = undefined, processInputs = true, removeComments = true, replaceAppMacros = true} = {}) {
     let newText = text;
 
     if (char) {
@@ -1005,6 +1016,14 @@ export function processMacros(text, {char = undefined, processInputs = true} = {
                 newText = newText.replace(match, value);
             });
     }
+
+    if (replaceAppMacros)
+        newText = substituteParams(newText);
+
+    if (removeComments)
+        newText = newText
+            .replaceAll(/\/\/.*(?=\n)/g, "")
+            .replaceAll(/\/\/.*(?=$)/g, "");
 
     return newText;
 }
@@ -1102,10 +1121,7 @@ export function fetchStatus({forceUIUpdate = false, depthModifier = 0, forceDept
 
             if (entry.key !== "" && value !== "") promptValue += entry.separator;
 
-            promptValue += value
-                .replaceAll(/\/\/.*(?=\}\})/g, "")
-                .replaceAll(/\/\/.*(?=\n)/g, "")
-                .replaceAll(/\/\/.*(?=$)/g, "");
+            promptValue += value;
         };
 
         if (!promptValue) continue;

--- a/index.js
+++ b/index.js
@@ -603,17 +603,6 @@ function addTracker(status, character) {
             let index;
             let newMacro = "";
 
-            if (chunk instanceof HTMLSpanElement) {
-                /**@type {HTMLInputElement}*/const inputNumber = chunk.querySelector('input[type="range"]');
-                const min = inputNumber.min;
-                const max = inputNumber.max;
-                const step = inputNumber.step;
-                const value = inputNumber.value;
-                index = ++countRange;
-                match = regexRangeInput;
-                newMacro = `{{range::${min}::${max}::${step}::${value}}}`;
-            }
-
             if (chunk instanceof HTMLTextAreaElement) {
                 const value = chunk.value;
                 index = ++countText;
@@ -623,6 +612,16 @@ function addTracker(status, character) {
 
 
             if (chunk instanceof HTMLInputElement) {
+                if (chunk.classList.contains("type-range")) {
+                    const min = chunk.min;
+                    const max = chunk.max;
+                    const step = chunk.step;
+                    const value = chunk.value;
+                    index = ++countRange;
+                    match = regexRangeInput;
+                    newMacro = `{{range::${min}::${max}::${step}::${value}}}`;
+                }
+
                 if (chunk.classList.contains("type-number")) {
                     const value = chunk.value;
                     index = ++countNumber;
@@ -822,15 +821,14 @@ function addTracker(status, character) {
             .forEach((/**@type {HTMLInputElement}*/inputRange) => {
                 /**@type {HTMLSpanElement}*/const fakeInput = inputRange.parentElement.querySelector(`#${inputRange.id}-display .value`);
 
-                inputRange.addEventListener("input", function(e) {
-                    /**@type {HTMLInputElement}*/
-                    // @ts-ignore
-                    const original = e.target;
-                    fakeInput.textContent = original.value;
+                const updateInput = function() {
+                    fakeInput.textContent = inputRange.value;
 
                     el(form, `input[name="${form_target}"]`).value = createInputStrings(newRow, el_target);
                     dispatchInput(form);
-                }, {passive: true});
+                };
+
+                $(inputRange).on('input', {passive: true}, updateInput);
 
                 inputRange.addEventListener("keypress", function(e) {
                     const { key } = e;
@@ -851,7 +849,7 @@ function addTracker(status, character) {
                     else if (nextValue > max) inputRange.value = max;
                     else inputRange.value = nextValue;
 
-                    dispatchInput(inputRange);
+                    updateInput();
                 });
 
                 inputRange.addEventListener("wheel", async (e) => {
@@ -874,7 +872,7 @@ function addTracker(status, character) {
                     else if (nextValue > max) inputRange.value = max;
                     else inputRange.value = nextValue;
 
-                    dispatchInput(inputRange);
+                    updateInput();
                 }, {passive: false});
 
                 fakeInput.addEventListener("click", () => inputRange.focus());

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.4.11",
+    "version": "1.0.0",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,496 @@
+{
+	"name": "SillyTavern-Stat-us-Maximus",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"devDependencies": {
+				"esbuild": "0.27.2"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.2",
+				"@esbuild/android-arm": "0.27.2",
+				"@esbuild/android-arm64": "0.27.2",
+				"@esbuild/android-x64": "0.27.2",
+				"@esbuild/darwin-arm64": "0.27.2",
+				"@esbuild/darwin-x64": "0.27.2",
+				"@esbuild/freebsd-arm64": "0.27.2",
+				"@esbuild/freebsd-x64": "0.27.2",
+				"@esbuild/linux-arm": "0.27.2",
+				"@esbuild/linux-arm64": "0.27.2",
+				"@esbuild/linux-ia32": "0.27.2",
+				"@esbuild/linux-loong64": "0.27.2",
+				"@esbuild/linux-mips64el": "0.27.2",
+				"@esbuild/linux-ppc64": "0.27.2",
+				"@esbuild/linux-riscv64": "0.27.2",
+				"@esbuild/linux-s390x": "0.27.2",
+				"@esbuild/linux-x64": "0.27.2",
+				"@esbuild/netbsd-arm64": "0.27.2",
+				"@esbuild/netbsd-x64": "0.27.2",
+				"@esbuild/openbsd-arm64": "0.27.2",
+				"@esbuild/openbsd-x64": "0.27.2",
+				"@esbuild/openharmony-arm64": "0.27.2",
+				"@esbuild/sunos-x64": "0.27.2",
+				"@esbuild/win32-arm64": "0.27.2",
+				"@esbuild/win32-ia32": "0.27.2",
+				"@esbuild/win32-x64": "0.27.2"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
+	"private": true,
 	"scripts": {
 		"release": "standard-version --release-as",
-        "docs:build": "jsdoc -c jsdoc.conf.json",
-        "docs:deploy": "npm run docs:build && gh-pages -d docs"
+		"build": "esbuild source/modules-bundle.js --bundle --format=esm --sourcemap --outfile=public/bundle.js --target=es2017",
+		"build:min": "esbuild source/modules-bundle.js --bundle --format=esm --minify --sourcemap --target=es2017 --outfile=public/bundle.min.js --target=es2017",
+		"build:nomap": "esbuild source/modules-bundle.js --bundle --format=esm --outfile=public/bundle.js --target=es2017",
+		"build:min:nomap": "esbuild source/modules-bundle.js --bundle --format=esm --minify --target=es2017 --outfile=public/bundle.min.js --target=es2017",
+		"build:watch": "esbuild source/modules-bundle.js --bundle --format=esm --sourcemap --outfile=public/bundle.js --target=es2017 --watch"
+	},
+	"devDependencies": {
+		"esbuild": "0.27.2"
 	}
 }

--- a/settings.html
+++ b/settings.html
@@ -27,6 +27,12 @@
 					<i class="right_menu_button fa-solid fa-circle-exclamation interactable" title="This will include the Stat blocks of group members that have not interacted with the chat, or their last message is out of the context, but are present" data-i18n="[title]This will include the Stat blocks of group members that have not interacted with the chat, or their last message is out of the context, but are present" tabindex="0" role="button"></i>
 				</label>
 
+				<label class="flex-container">
+					<input id="stat-us-max-auto-save-metadata" stat-us-max-setting="autoSaveMetadata" type="checkbox" />
+					Automatically save metadata
+					<i class="right_menu_button fa-solid fa-circle-exclamation interactable" title="In long chats, saving metadata can freeze the browser, disabling this option will prevent this at the cost of having to manually save your changes" data-i18n="[title]In long chats, saving metadata can freeze the browser, disabling this option will prevent this at the cost of having to manually save your changes" tabindex="0" role="button"></i>
+				</label>
+
 				<label class="d-flex flex-col flex-start-center gap-5px">
                     <small class="text-quote">Set the minimum prompt injection depth</small>
 					<input id="stat-us-max-min-prompt-depth" stat-us-max-setting="minPromptDepth" type="number" min="0" max="10000" step="1" class="text_pole textarea_compact mt-0" />

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -1,4 +1,5 @@
-import { characters, chat, chat_metadata, event_types, eventSource, scrollChatToBottom, this_chid, user_avatar } from "../../../../../../script.js";
+import { characters, chat, chat_metadata, eventSource, scrollChatToBottom, this_chid, user_avatar } from "../../../../../../script.js";
+import { event_types } from "../../../../../events.js";
 import { selected_group } from "../../../../../group-chats.js";
 import { power_user } from "../../../../../power-user.js";
 import { addGroupStatusButtons, callbacksClickValueUID, extensionSettings, fetchStatus, fetchStatusDebounced, getActiveParticipants, getStatusDepth, log } from "../../index.js";
@@ -44,6 +45,10 @@ export function startListeners() {
     eventSource.on('groupSelected', async (...args) => { // WTF - Why isn't this in event_types?
         log("groupSelected", args);
         addGroupStatusButtons();
+    });
+
+    eventSource.on(event_types.CHARACTER_RENAMED_IN_PAST_CHAT, async (currentChat, oldAvatar, newAvatar) => {
+        // log(currentChat, oldAvatar, newAvatar);
     });
 
     eventSource.makeFirst(event_types.CHAT_CHANGED, async (...args) => {

--- a/source/js/eventListeners.js
+++ b/source/js/eventListeners.js
@@ -74,6 +74,20 @@ export function startListeners() {
         if (!chat_metadata.stat_us_maximus) chat_metadata.stat_us_maximus = [];
     });
 
+    eventSource.on(event_types.CHARACTER_RENAMED_IN_PAST_CHAT, function (currentChat, oldAvatar, newAvatar) {
+        log("CHARACTER_RENAMED_IN_PAST_CHAT", currentChat, oldAvatar, newAvatar);
+
+        const metadata = currentChat[0]?.chat_metadata ?? false;
+        if (!metadata) return;
+        if (!metadata?.stat_us_maximus) metadata.stat_us_maximus = [];
+
+        metadata.stat_us_maximus = metadata.stat_us_maximus.map(stat => {
+            if (String(stat.avatar) === String(oldAvatar)) stat.avatar = String(newAvatar);
+
+            return stat;
+        });
+    });
+
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, async (...args) => {
         log("CHARACTER_MESSAGE_RENDERED", args);
         fetchStatus();

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -6,7 +6,7 @@ import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
 import { destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
-import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, saveMetadataSTUM } from "./statusControls.js";
+import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue } from "./statusControls.js";
 
 /*  # TODO
     - [X] Select for alt_values
@@ -154,11 +154,6 @@ function getFullCharAvatar(status) {
 const DEBOUNCE_MS = 400;
 let formDebounceTimer;
 let altKeyDebounceTimer;
-let forceDepthDebounceTimer;
-let separatorDebounceTimer;
-let defEntrySeparatorDebounceTimer;
-let prefixDebounceTimer;
-let suffixDebounceTimer;
 
 /**
  * @param {HTMLElement} target
@@ -627,48 +622,26 @@ export function getCharStatusForm(char) {
 
     selectEntryRole.addEventListener("input", () => {
         metadata.role = Number(selectEntryRole.value);
-
-        saveMetadataSTUM();
     }, { passive: true });
 
     numberAreaForDepth.addEventListener("input", () => {
         metadata.forceDepth = parseValue(numberAreaForDepth.value);
-
-        clearTimeout(forceDepthDebounceTimer);
-
-        forceDepthDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     }, { passive: true });
 
     textareaStatusSeparator.addEventListener("input", () => {
         metadata.separator = un_escapeNewlines(textareaStatusSeparator.value);
-
-        clearTimeout(separatorDebounceTimer);
-
-        separatorDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     }, { passive: true });
 
     textareaDefEntrySeparator.addEventListener("input", () => {
         metadata.def_entry_separator = un_escapeNewlines(textareaDefEntrySeparator.value);
-
-        clearTimeout(defEntrySeparatorDebounceTimer);
-
-        defEntrySeparatorDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     }, { passive: true });
 
     textareaStatusPrefix.addEventListener("input", () => {
         metadata.prefix = un_escapeNewlines(textareaStatusPrefix.value);
-
-        clearTimeout(prefixDebounceTimer);
-
-        prefixDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     }, { passive: true });
 
     textareaStatusSuffix.addEventListener("input", () => {
         metadata.suffix = un_escapeNewlines(textareaStatusSuffix.value);
-
-        clearTimeout(suffixDebounceTimer);
-
-        suffixDebounceTimer = window.setTimeout(() => saveMetadataSTUM(), DEBOUNCE_MS);
     }, { passive: true });
 
     cloneStatsBtn.addEventListener("click", async () => {
@@ -746,7 +719,10 @@ export async function popupStatusSingleChar(char) {
         okButton: t`Close Status`,
         allowVerticalScrolling: true,
         wide: true,
-        onClose: async () => destroyElement(container)
+        onClose: async () => {
+            SillyTavern.getContext().saveMetadataDebounced();
+            destroyElement(container)
+        }
     });
 
     fetchStatusDebounced({forceUIUpdate: true});
@@ -766,7 +742,10 @@ export async function popupStatusMultiChar(chars) {
         okButton: t`Close Status`,
         allowVerticalScrolling: true,
         wide: true,
-        onClose: async () => destroyElement(content)
+        onClose: async () => {
+            SillyTavern.getContext().saveMetadataDebounced();
+            destroyElement(content)
+        }
     });
 
     fetchStatusDebounced({forceUIUpdate: true});

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -6,7 +6,7 @@ import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
 import { destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
-import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, updateCharEntry, getCharAltValue, flushCharAltValues, updateCharAltValue } from "./statusControls.js";
+import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, updateCharEntry, getCharAltValue, flushCharAltValues, updateCharAltValue, evaluateEntry } from "./statusControls.js";
 
 /*  # TODO
     - [X] Select for alt_values
@@ -320,12 +320,14 @@ function addStatusRow({data = [], container, template, char}) {
 
             try {
                 newEntry = await navigator.clipboard.readText();
+                newEntry = JSON.parse(newEntry);
             } catch (error) {
                 console.error('Error reading clipboard:', error);
-                return toastr.warning(t`Failed to read clipboard text. Have you granted the permission?`);
+                return toastr.warning(t`Failed to read clipboard text. Make sure you granted permissions and the text is a JSON object.`);
             }
 
-            newEntry = JSON.parse(newEntry);
+            if (!newEntry) return toastr.warning(t`Your clipboard has wrong metadata format: JSON expected`);
+            if (!evaluateEntry(newEntry)) return;
 
             const newSelect = {
                 value_uid: false,

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -42,26 +42,26 @@ export function un_escapeNewlines(str) {
         .replace(/\\r/g, "\r");
 }
 
-async function popupDeleteConfirm(del_name = "this") {
-    const delete_title = document.createElement("div");
-    delete_title.textContent = t`WARNING`;
-    delete_title.classList.add("fw-bolder");
+async function popupConfirmAction(del_name = "this") {
+    const confirm_title = document.createElement("div");
+    confirm_title.textContent = t`WARNING`;
+    confirm_title.classList.add("fw-bolder");
 
-    const delete_text = document.createElement("div");
-    delete_text.textContent = t`Are you sure want to delete ${del_name}?`;
+    const confirm_text = document.createElement("div");
+    confirm_text.textContent = t`Are you sure want to ${del_name}?`;
 
-    const delete_container = document.createElement("div");
-    delete_container.classList.add("d-flex", "flex-col", "flex-center", "w-100", "mb-5px", "gap-5px");
-    delete_container.append(delete_title, delete_text);
+    const confirm_container = document.createElement("div");
+    confirm_container.classList.add("d-flex", "flex-col", "flex-center", "w-100", "mb-5px", "gap-5px");
+    confirm_container.append(confirm_title, confirm_text);
 
-    const delete_css_block = document.createElement("div");
-    delete_css_block.classList.add("stat-us-max-custom-css");
-    delete_css_block.append(delete_container);
+    const confirm_css_block = document.createElement("div");
+    confirm_css_block.classList.add("stat-us-max-custom-css");
+    confirm_css_block.append(confirm_container);
 
-    return await callGenericPopup(delete_css_block, POPUP_TYPE.CONFIRM, "", {
+    return await callGenericPopup(confirm_css_block, POPUP_TYPE.CONFIRM, "", {
         okButton: t`Confirm`,
         cancelButton: t`Cancel`,
-        onClose: () => destroyElement(delete_css_block)
+        onClose: () => destroyElement(confirm_css_block)
     });
 };
 
@@ -287,7 +287,7 @@ function addStatusRow({data = [], container, template, char}) {
         }, { passive: true });
 
         newRow.querySelector(".del_alt_value").addEventListener("click", async function () {
-            if (await popupDeleteConfirm("the alt value") === 0) return;
+            if (await popupConfirmAction("delete the alt value") === 0) return;
 
             try {
                 await updateCharEntry(char, entry.uid, new FormData(newRow), true);
@@ -331,7 +331,7 @@ function addStatusRow({data = [], container, template, char}) {
         });
 
         newRow.querySelector(".delete-row").addEventListener("click", async function () {
-            if (await popupDeleteConfirm("the alt value") === 0) return;
+            if (await popupConfirmAction("delete the alt value") === 0) return;
 
             removeCharEntry(char, entry.uid);
             destroyElement(newRow);
@@ -672,7 +672,7 @@ export function getCharStatusForm(char) {
     }, { passive: true });
 
     deleteStatsBtn.addEventListener("click", async () => {
-        if (await popupDeleteConfirm(`${char.name}'s status data`) === 0) return;
+        if (await popupConfirmAction(`delete ${char.name}'s status data`) === 0) return;
 
         const success = deleteCharStatus(char);
 

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -6,7 +6,7 @@ import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
 import { destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
-import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue } from "./statusControls.js";
+import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, updateCharEntry, getCharAltValue } from "./statusControls.js";
 
 /*  # TODO
     - [X] Select for alt_values
@@ -164,13 +164,19 @@ function el(target, class_name) {
     return target.querySelector(class_name);
 }
 
-/** @param {HTMLElement} el */
-function toggleSwitch(el, callback = (param) => {}) {
+/**
+ * @param {HTMLElement} parent
+ * @param {string} selector
+ * @returns {boolean}
+ */
+function toggleSwitch(parent, selector) {
     // True if the final state is on
-    const state = !el.classList.contains("fa-toggle-on");
-    el.classList.toggle("fa-toggle-off", !state);
-    el.classList.toggle("fa-toggle-on", state);
-    callback(state);
+    /** @type {HTMLElement} */
+    const elem = el(parent, selector);
+    const isOn = !elem.classList.contains("fa-toggle-on");
+    elem.classList.toggle("fa-toggle-on", isOn);
+    elem.classList.toggle("fa-toggle-off", !isOn);
+    return isOn;
 };
 
 function refreshAltValues(target, alts, select_uid = 0) {
@@ -192,107 +198,114 @@ function refreshAltValues(target, alts, select_uid = 0) {
 };
 
 const evChange = new Event('change', { bubbles: true, cancelable: true });
-const evInput = new Event('input', { bubbles: true, cancelable: true });
 
-function addStatusRow({amount = 1, data = [], container, template, char} = {}) {
-    for (let i = 0; i < amount; i++) {
+/**
+ * Add a new entry row to the active status popup block
+ * @param {object} options
+ * @param {object[]} options.data
+ * @param {HTMLElement} options.container
+ * @param {HTMLElement} options.template
+ * @param {object} options.char
+ * @returns void
+ */
+function addStatusRow({data = [], container, template, char}) {
+    for (const entryData of data) {
+        let entry = getCharEntry(char, entryData.uid);
         const newRow = /** @type {HTMLFormElement} */ (template.cloneNode(true));
 
         // @ts-ignore
-        if (!data[i]) return toastr.warning(t`Data for new entry is empty - index=${i}`);
+        if (!entry) return toastr.warning(t`Data for new entry is empty - index=${i}`);
 
-        newRow.dataset.uid = data[i].uid;
+        newRow.dataset.uid = entry.uid;
+        newRow.dataset.charAvatar = char.avatar;
         newRow.removeAttribute('action');
 
         // Set Values
-        el(newRow, 'input[name="key"]').value = data[i].key;
-        el(newRow, 'input[name="separator"]').value = escapeNewlines(data[i].separator);
-        el(newRow, 'textarea[name="value"]').value = data[i].value;
-        el(newRow, 'input[name="enabled"]').value = data[i].enabled;
-        refreshAltValues(newRow, data[i].alt_values, data[i].value_uid);
-        el(newRow, 'select[name="value_uid"]').value = String(data[i].value_uid);
-        el(newRow, 'input[name="alt_key"]').value = data[i].alt_values.find(alt => alt.uid === data[i].value_uid).key;
+        const inputEntryEnabled = /** @type {HTMLInputElement} */ (newRow.querySelector('input[name="enabled"]'));
+        inputEntryEnabled.value = String(entry.enabled);
 
-        if (!data[i].enabled) toggleSwitch(el(newRow, ".kill-switch"));
+        const inputKey = /** @type {HTMLInputElement} */ (newRow.querySelector('input[name="key"]'));
+        inputKey.value = entry.key;
+
+        const textareaValue = /** @type {HTMLTextAreaElement} */ (newRow.querySelector('textarea[name="value"]'));
+        textareaValue.value = entry.value;
+
+        const inputSeparator = /** @type {HTMLInputElement} */ (newRow.querySelector('input[name="separator"]'));
+        inputSeparator.value = escapeNewlines(entry.separator);
+
+        const selectAltValues = /** @type {HTMLSelectElement} */ (newRow.querySelector('select[name="value_uid"]'));
+        selectAltValues.value = String(entry.value_uid);
+        selectAltValues.dataset.prevValue = String(entry.value_uid);
+        refreshAltValues(newRow, entry.alt_values, entry.value_uid);
+
+        const inputAltKey = /** @type {HTMLInputElement} */ (newRow.querySelector('input[name="alt_key"]'));
+        inputAltKey.value = entry.alt_values.find(alt => alt.uid === entry.value_uid).key;
+
+        if (!entry.enabled) toggleSwitch(newRow, ".kill-switch");
 
         // Add listeners
-        newRow.addEventListener("submit", (e) => {
-            e.preventDefault();
-
-            const formData = new FormData(newRow);
-
-            updateCharEntry(char, data[i].uid, formData);
-        }, { passive: false });
-
-        newRow.addEventListener("input", () => {
-            clearTimeout(formDebounceTimer);
-
-            formDebounceTimer = window.setTimeout(() => newRow.requestSubmit(), DEBOUNCE_MS);
+        newRow.querySelector(".kill-switch").addEventListener("click", function () {
+            const newState = toggleSwitch(newRow, ".kill-switch");
+            inputEntryEnabled.value = String(newState);
         }, { passive: true });
 
-        el(newRow, 'select[name="value_uid"]').addEventListener("change", () => {
-            const alt = getCharAltValue(char, data[i].uid, el(newRow, 'select[name="value_uid"]').value);
+        selectAltValues.addEventListener("change", async function () {
+            const newValue = selectAltValues.value;
 
-            el(newRow, 'input[name="alt_key"]').value = alt.key;
-            el(newRow, 'textarea[name="value"]').value = alt.value;
+            selectAltValues.value = selectAltValues.dataset.prevValue;
+            await updateCharEntry(char, entry.uid, new FormData(newRow), true);
 
-            newRow.dispatchEvent(evInput);
+            selectAltValues.value = newValue;
+            selectAltValues.dataset.prevValue = newValue;
+            const alt = getCharAltValue(char, entry.uid, selectAltValues.value);
+
+            inputAltKey.value = alt.key;
+            textareaValue.value = alt.value;
         }, { passive: true });
 
-        el(newRow, ".delete-row").addEventListener("click", async () => {
-            if (await popupDeleteConfirm("the alt value") === 0) return;
-
-            removeCharEntry(char, data[i].uid);
-            destroyElement(newRow);
+        inputAltKey.addEventListener("input", function () {
+            /** @type {HTMLOptionElement} */
+            const optionInDisplay = selectAltValues.querySelector(`option[value="${selectAltValues.value}"]`);
+            optionInDisplay.text = inputAltKey.value;
         }, { passive: true });
 
-        el(newRow, ".kill-switch").addEventListener("click", () => {
-            toggleSwitch(el(newRow, ".kill-switch"), (state) => el(newRow, 'input[name="enabled"]').value = state);
-            newRow.requestSubmit();
-        }, { passive: true });
+        newRow.querySelector(".add_alt_value").addEventListener("click", async function () {
+            await updateCharEntry(char, entry.uid, new FormData(newRow), true);
 
-        el(newRow, 'input[name="alt_key"]').addEventListener("keyup", () => {
-            clearTimeout(altKeyDebounceTimer);
-
-            altKeyDebounceTimer = window.setTimeout(() => refreshAltValues(
-                newRow,
-                getCharEntry(char, data[i].uid).alt_values,
-                el(newRow, 'select[name="value_uid"]').value
-            ), DEBOUNCE_MS);
-        }, { passive: true });
-
-        el(newRow, ".add_alt_value").addEventListener("click", () => {
-            const newAlt = addCharAltValue(char, data[i].uid);
+            const newAlt = addCharAltValue(char, entry.uid);
 
             if (!newAlt) return;
 
-            refreshAltValues(newRow, getCharEntry(char, data[i].uid).alt_values, newAlt.uid);
-
-            el(newRow, 'select[name="value_uid"]').value = String(newAlt.uid);
-            el(newRow, 'select[name="value_uid"]').dispatchEvent(evChange);
+            refreshAltValues(newRow, entry.alt_values, newAlt.uid);
+            selectAltValues.value = String(newAlt.uid);
+            selectAltValues.dispatchEvent(evChange);
         }, { passive: true });
 
-        el(newRow, ".del_alt_value").addEventListener("click", async () => {
+        newRow.querySelector(".del_alt_value").addEventListener("click", async function () {
             if (await popupDeleteConfirm("the alt value") === 0) return;
 
             try {
-                const success = removeCharAltValue(char, data[i].uid, el(newRow, 'select[name="value_uid"]').value);
+                await updateCharEntry(char, entry.uid, new FormData(newRow), true);
+
+                const success = removeCharAltValue(char, entry.uid, selectAltValues.value);
 
                 if (!success) return;
 
-                const new_alts = getCharEntry(char, data[i].uid).alt_values;
+                entry = getCharEntry(char, entry.uid);
+                const firstAlt = entry.alt_values[0];
 
-                refreshAltValues(newRow, new_alts);
-
-                el(newRow, 'select[name="value_uid"]').value = String(new_alts[0].uid);
-                el(newRow, 'select[name="value_uid"]').dispatchEvent(evChange);
+                refreshAltValues(newRow, entry.alt_values, firstAlt.uid);
+                selectAltValues.value = String(firstAlt.uid);
+                selectAltValues.dataset.prevValue = String(firstAlt.uid);
+                inputAltKey.value = firstAlt.key;
+                textareaValue.value = firstAlt.value;
             } catch (error) {
                 // ...
             }
         }, { passive: true });
 
-        el(newRow, ".menu_button.export").addEventListener("click", async function() {
-            const currentEntry = getCharEntry(char, data[i].uid);
+        newRow.querySelector(".menu_button.export").addEventListener("click", async function() {
+            const currentEntry = getCharEntry(char, entry.uid);
 
             await exportObjectToClipboard(currentEntry);
         }, { passive: true });
@@ -307,22 +320,25 @@ function addStatusRow({amount = 1, data = [], container, template, char} = {}) {
                 if (macroType === "boolean") macroTemplate = "{{boolean::true::true::false}}";
                 if (macroType === "range") macroTemplate = "{{range::0::100::1::0}}";
 
-                if (extensionSettings.altMacroTemplateBehavior) {
-                    const valueTextarea = el(newRow, 'textarea[name="value"]')
-                    valueTextarea.value += macroTemplate;
-                    valueTextarea.dispatchEvent(evInput);
-
-                    return;
-                } else {
-                    await copyText(macroTemplate);
-                }
+                if (extensionSettings.altMacroTemplateBehavior) textareaValue.value += macroTemplate;
+                else await copyText(macroTemplate);
             }, { passive: true });
         });
+
+        newRow.querySelector(".delete-row").addEventListener("click", async function () {
+            if (await popupDeleteConfirm("the alt value") === 0) return;
+
+            removeCharEntry(char, entry.uid);
+            destroyElement(newRow);
+        }, { passive: true });
 
         container.append(newRow);
     }
 }
 
+/**
+ * @returns {HTMLDivElement}
+ */
 export function getCharStatusForm(char) {
     let metadata = getCharStatus(char);
 
@@ -690,7 +706,6 @@ export function getCharStatusForm(char) {
 
     /** Add def rows */
     if (metadata.entries.length > 0) addStatusRow({
-        amount: metadata.entries.length,
         data: metadata.entries,
         container: content,
         template: formRow,
@@ -713,27 +728,39 @@ export function getCharStatusForm(char) {
 }
 
 export async function popupStatusSingleChar(char) {
-    const container = await getCharStatusForm(char);
+    const charFrom = await getCharStatusForm(char);
 
-    await callGenericPopup(container, POPUP_TYPE.TEXT, "", {
+    if (!charFrom) return;
+
+    await callGenericPopup(charFrom, POPUP_TYPE.TEXT, "", {
         okButton: t`Close Status`,
         allowVerticalScrolling: true,
         wide: true,
         onClose: async () => {
-            SillyTavern.getContext().saveMetadataDebounced();
-            destroyElement(container)
+            const forms = charFrom.querySelectorAll('form');
+
+            for (const form of forms)
+                updateCharEntry(char, form.dataset.uid, new FormData(form));
+
+            destroyElement(charFrom)
         }
     });
 
     fetchStatusDebounced({forceUIUpdate: true});
 }
 
+/**
+ * @param {object[]} chars
+ */
 export async function popupStatusMultiChar(chars) {
     const content = document.createElement("div");
     content.id = "stat-us-max-popup-multi-char";
 
     for (const char of chars) {
         const charForm = await getCharStatusForm(char);
+
+        if (!charForm) continue;
+
         charForm.classList.add("multi-char-popup");
         content.append(charForm);
     }
@@ -743,7 +770,16 @@ export async function popupStatusMultiChar(chars) {
         allowVerticalScrolling: true,
         wide: true,
         onClose: async () => {
-            SillyTavern.getContext().saveMetadataDebounced();
+            const forms = content.querySelectorAll('form');
+
+            for (const form of forms) {
+                const char = chars.find(char => char.avatar === form.dataset.charAvatar);
+
+                if (!char) continue;
+
+                updateCharEntry(char, form.dataset.uid, new FormData(form));
+            }
+
             destroyElement(content)
         }
     });

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -177,18 +177,18 @@ export function getCharStatusForm(char) {
 
     /**
      * Creates a button element with specified classes and title.
-     * @param {string} title - The title and data-i18n attribute for the button
-     * @param {string[]} classes - Array of class names to add to the button
-     * @param {object} data - Additional data attributes to set on the button
+     * @param {string?} title - The title and data-i18n attribute for the button
+     * @param {string[]?} classes - Array of class names to add to the button
+     * @param {object?} data - Additional data attributes to set on the button
      * @returns {HTMLDivElement} The created button element
      */
-    const createButton = function(title, classes, data) {
+    const createButton = function(title = "", classes = [], data = {}) {
         const button = document.createElement("div");
         button.title = title;
         button.dataset.i18n = title;
         button.classList.add("menu_button", "menu_button_icon", "fa-fw", "fa-solid", "interactable", "m-0", ...classes);
 
-        for (const [key, value] of Object.entries(data || {}))
+        for (const [key, value] of Object.entries(data))
             button.dataset[key] = value;
 
         return button;

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -6,7 +6,7 @@ import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
 import { destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
-import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, updateCharEntry, getCharAltValue } from "./statusControls.js";
+import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, updateCharEntry, getCharAltValue, flushCharAltValues, updateCharAltValue } from "./statusControls.js";
 
 /*  # TODO
     - [X] Select for alt_values
@@ -308,6 +308,68 @@ function addStatusRow({data = [], container, template, char}) {
             } catch (error) {
                 // ...
             }
+        }, { passive: true });
+
+        newRow.querySelector(".menu_button.import").addEventListener("click", async function() {
+            if (await popupConfirmAction("overwrite the data of this entry") === 0) return;
+
+            let newEntry;
+
+            if (!navigator.clipboard)
+                return toastr.warning(t`Clipboard API not available in this context.`);
+
+            try {
+                newEntry = await navigator.clipboard.readText();
+            } catch (error) {
+                console.error('Error reading clipboard:', error);
+                return toastr.warning(t`Failed to read clipboard text. Have you granted the permission?`);
+            }
+
+            newEntry = JSON.parse(newEntry);
+
+            const newSelect = {
+                value_uid: false,
+                alt_values: []
+            };
+
+            for (const [k, v] of Object.entries(newEntry)) {
+                if (k === "display_position" || k === "uid") continue;
+
+                if (k === "alt_values" || k === "value_uid") {
+                    newSelect[k] = v;
+                    continue;
+                }
+
+                /** @type {HTMLInputElement|HTMLSelectElement|HTMLTextAreaElement} */
+                const input = newRow.querySelector(`[name="${k}"]`);
+                input.value = String(v);
+            }
+
+            flushCharAltValues(char, entry.uid, true);
+
+            entry = getCharEntry(char, entry.uid);
+
+            const formDataFirstEntry = new FormData();
+            formDataFirstEntry.set("key", newSelect.alt_values[0].key);
+            formDataFirstEntry.set("value", newSelect.alt_values[0].value);
+            updateCharAltValue(char, entry.uid, entry.alt_values[0].uid, formDataFirstEntry);
+
+            for (const alt of newSelect.alt_values.slice(1))
+                addCharAltValue(char, entry.uid, {value: alt.value, key: alt.key});
+
+            entry = getCharEntry(char, entry.uid);
+
+            newSelect.value_uid = entry.value_uid;
+            newSelect.alt_values = entry.alt_values;
+            const selectedAlt = newSelect.alt_values.find(alt => alt.uid === newSelect.value_uid);
+
+            toggleSwitch(newRow, ".kill-switch", newEntry.enabled);
+            refreshAltValues(newRow, newSelect.alt_values, selectedAlt.uid);
+            selectAltValues.value = String(selectedAlt.uid);
+            selectAltValues.dataset.prevValue = String(selectedAlt.uid);
+            inputAltKey.value = String(selectedAlt.key);
+
+            updateCharEntry(char, entry.uid, new FormData(newRow), false);
         }, { passive: true });
 
         newRow.querySelector(".menu_button.export").addEventListener("click", async function() {

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -327,14 +327,13 @@ function addStatusRow({data = [], container, template, char}) {
             if (!evaluateEntry(newEntry)) return;
 
             const newSelect = {
-                value_uid: false,
                 alt_values: []
             };
 
             for (const [k, v] of Object.entries(newEntry)) {
-                if (k === "display_position" || k === "uid") continue;
+                if (k === "display_position" || k === "uid" || k === "value_uid") continue;
 
-                if (k === "alt_values" || k === "value_uid") {
+                if (k === "alt_values") {
                     newSelect[k] = v;
                     continue;
                 }
@@ -351,6 +350,7 @@ function addStatusRow({data = [], container, template, char}) {
             const formDataFirstEntry = new FormData();
             formDataFirstEntry.set("key", newSelect.alt_values[0].key);
             formDataFirstEntry.set("value", newSelect.alt_values[0].value);
+
             updateCharAltValue(char, entry.uid, entry.alt_values[0].uid, formDataFirstEntry);
 
             for (const alt of newSelect.alt_values.slice(1))
@@ -367,8 +367,9 @@ function addStatusRow({data = [], container, template, char}) {
             selectAltValues.value = String(selectedAlt.uid);
             selectAltValues.dataset.prevValue = String(selectedAlt.uid);
             inputAltKey.value = String(selectedAlt.key);
+            textareaValue.value = String(selectedAlt.value);
 
-            updateCharEntry(char, entry.uid, new FormData(newRow), false);
+            await updateCharEntry(char, entry.uid, new FormData(newRow), false);
         }, { passive: true });
 
         newRow.querySelector(".menu_button.export").addEventListener("click", async function() {

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -812,10 +812,23 @@ export async function popupStatusSingleChar(char) {
         wide: true,
         onClose: async () => {
             const forms = charForm.querySelectorAll('form');
+            let headerInputsModified = false;
 
-            for (const form of forms)
-                if (String(form.dataset.modified) === "true")
+            for (const form of forms) {
+                if (String(form.dataset.modified) !== "true") continue;
+
+                if (form.classList.contains("stat-us-max-popup-row"))
                     updateCharEntry(char, form.dataset.uid, new FormData(form), false);
+
+                if (form.classList.contains("stat-wrapper"))
+                    headerInputsModified = true;
+            }
+
+            if (headerInputsModified) {
+                setSaveStateFlag(extensionSettings.autoSaveMetadata);
+
+                if (extensionSettings.autoSaveMetadata) SillyTavern.getContext().saveChat();
+            }
 
             destroyElement(charForm);
         }

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -5,7 +5,7 @@ import { t } from "../../../../../i18n.js";
 import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
-import { destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
+import { destroyElement, fetchStatusDebounced, extensionSettings, setSaveStateFlag } from "../../index.js";
 import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, updateCharEntry, getCharAltValue, flushCharAltValues, updateCharAltValue, evaluateEntry } from "./statusControls.js";
 
 /*  # TODO
@@ -404,7 +404,7 @@ function addStatusRow({data = [], container, template, char}) {
 }
 
 /**
- * @returns {HTMLDivElement}
+ * @returns {HTMLElement}
  */
 export function getCharStatusForm(char) {
     let metadata = getCharStatus(char);
@@ -455,7 +455,7 @@ export function getCharStatusForm(char) {
      * @param {string[]?} classes - Array of class names to add to the button
      * @param {object?} data - Additional data attributes to set on the button
      * @param {string?} element_type - Type of the HTML element to create
-     * @returns {HTMLDivElement} The created button element
+     * @returns {HTMLElement} The created button element
      */
     const createRowWrapper = (elements = [], classes = [], data = {}, element_type = "div") => {
         const row = document.createElement(element_type);
@@ -667,7 +667,7 @@ export function getCharStatusForm(char) {
         createInputLabel(textareaStatusPrefix),
         createInputLabel(textareaStatusSuffix),
         statusHeaderButtons
-    ], ["flex-end-start", "w-100", "gap-5px", "stat-wrapper"]);
+    ], ["flex-end-start", "w-100", "gap-5px", "stat-wrapper"], {modified: false, charAvatar: char.avatar}, "form");
 
     const statusHeaderForm = createRowWrapper([
         avatarContainer,
@@ -704,28 +704,34 @@ export function getCharStatusForm(char) {
         });
     }, { passive: true });
 
-    selectEntryRole.addEventListener("input", () => {
+    selectEntryRole.addEventListener("change", () => {
         metadata.role = Number(selectEntryRole.value);
+        statusHeaderInputs.dataset.modified = String(true);
     }, { passive: true });
 
     numberAreaForDepth.addEventListener("input", () => {
         metadata.forceDepth = parseValue(numberAreaForDepth.value);
+        statusHeaderInputs.dataset.modified = String(true);
     }, { passive: true });
 
     textareaStatusSeparator.addEventListener("input", () => {
         metadata.separator = un_escapeNewlines(textareaStatusSeparator.value);
+        statusHeaderInputs.dataset.modified = String(true);
     }, { passive: true });
 
     textareaDefEntrySeparator.addEventListener("input", () => {
         metadata.def_entry_separator = un_escapeNewlines(textareaDefEntrySeparator.value);
+        statusHeaderInputs.dataset.modified = String(true);
     }, { passive: true });
 
     textareaStatusPrefix.addEventListener("input", () => {
         metadata.prefix = un_escapeNewlines(textareaStatusPrefix.value);
+        statusHeaderInputs.dataset.modified = String(true);
     }, { passive: true });
 
     textareaStatusSuffix.addEventListener("input", () => {
         metadata.suffix = un_escapeNewlines(textareaStatusSuffix.value);
+        statusHeaderInputs.dataset.modified = String(true);
     }, { passive: true });
 
     cloneStatsBtn.addEventListener("click", async () => {
@@ -757,7 +763,7 @@ export function getCharStatusForm(char) {
             );
 
             refreshButton.addEventListener("click", () => {
-                /**@type {HTMLDivElement}*/
+                /**@type {HTMLElement}*/
                 const newContainer = getCharStatusForm(char);
                 const nodesArray = Array.from(newContainer.childNodes);
 
@@ -840,6 +846,7 @@ export async function popupStatusMultiChar(chars) {
         wide: true,
         onClose: async () => {
             const forms = content.querySelectorAll('form');
+            let headerInputsModified = false;
 
             for (const form of forms) {
                 const char = chars.find(char => char.avatar === form.dataset.charAvatar);
@@ -847,7 +854,17 @@ export async function popupStatusMultiChar(chars) {
                 if (!char) continue;
                 if (String(form.dataset.modified) === "false") continue;
 
-                updateCharEntry(char, form.dataset.uid, new FormData(form), false);
+                if (form.classList.contains("stat-us-max-popup-row"))
+                    updateCharEntry(char, form.dataset.uid, new FormData(form), false);
+
+                if (form.classList.contains("stat-wrapper"))
+                    headerInputsModified = true;
+            }
+
+            if (headerInputsModified) {
+                setSaveStateFlag(extensionSettings.autoSaveMetadata);
+
+                if (extensionSettings.autoSaveMetadata) SillyTavern.getContext().saveChat();
             }
 
             destroyElement(content);

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -151,10 +151,6 @@ function getFullCharAvatar(status) {
     return getThumbnailUrl(status.is_user ? "persona" : "avatar", status.avatar);
 }
 
-const DEBOUNCE_MS = 400;
-let formDebounceTimer;
-let altKeyDebounceTimer;
-
 /**
  * @param {HTMLElement} target
  * @param {string} class_name
@@ -253,6 +249,7 @@ function addStatusRow({data = [], container, template, char}) {
         newRow.querySelector(".kill-switch").addEventListener("click", function () {
             const newState = toggleSwitch(newRow, ".kill-switch");
             inputEntryEnabled.value = String(newState);
+            newRow.dataset.modified = String(true);
         }, { passive: true });
 
         selectAltValues.addEventListener("change", function () {
@@ -810,7 +807,7 @@ export async function popupStatusSingleChar(char) {
             const forms = charForm.querySelectorAll('form');
 
             for (const form of forms)
-                if (form.dataset.modified === "true")
+                if (String(form.dataset.modified) === "true")
                     updateCharEntry(char, form.dataset.uid, new FormData(form), false);
 
             destroyElement(charForm);
@@ -847,7 +844,7 @@ export async function popupStatusMultiChar(chars) {
                 const char = chars.find(char => char.avatar === form.dataset.charAvatar);
 
                 if (!char) continue;
-                if (form.dataset.modified === "false") continue;
+                if (String(form.dataset.modified) === "false") continue;
 
                 updateCharEntry(char, form.dataset.uid, new FormData(form), false);
             }

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -733,22 +733,22 @@ export function getCharStatusForm(char) {
 }
 
 export async function popupStatusSingleChar(char) {
-    const charFrom = await getCharStatusForm(char);
+    const charForm = await getCharStatusForm(char);
 
-    if (!charFrom) return;
+    if (!charForm) return;
 
-    await callGenericPopup(charFrom, POPUP_TYPE.TEXT, "", {
+    await callGenericPopup(charForm, POPUP_TYPE.TEXT, "", {
         okButton: t`Close Status`,
         allowVerticalScrolling: true,
         wide: true,
         onClose: async () => {
-            const forms = charFrom.querySelectorAll('form');
+            const forms = charForm.querySelectorAll('form');
 
             for (const form of forms)
                 if (form.dataset.modified === "true")
                     updateCharEntry(char, form.dataset.uid, new FormData(form));
 
-            destroyElement(charFrom);
+            destroyElement(charForm);
         }
     });
 

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -167,13 +167,14 @@ function el(target, class_name) {
 /**
  * @param {HTMLElement} parent
  * @param {string} selector
+ * @param {boolean?} forceState
  * @returns {boolean}
  */
-function toggleSwitch(parent, selector) {
+function toggleSwitch(parent, selector, forceState = null) {
     // True if the final state is on
     /** @type {HTMLElement} */
     const elem = el(parent, selector);
-    const isOn = !elem.classList.contains("fa-toggle-on");
+    const isOn = forceState === null ? !elem.classList.contains("fa-toggle-on") : forceState;
     elem.classList.toggle("fa-toggle-on", isOn);
     elem.classList.toggle("fa-toggle-off", !isOn);
     return isOn;
@@ -254,11 +255,11 @@ function addStatusRow({data = [], container, template, char}) {
             inputEntryEnabled.value = String(newState);
         }, { passive: true });
 
-        selectAltValues.addEventListener("change", async function () {
+        selectAltValues.addEventListener("change", function () {
             const newValue = selectAltValues.value;
 
             selectAltValues.value = selectAltValues.dataset.prevValue;
-            await updateCharEntry(char, entry.uid, new FormData(newRow), true);
+            updateCharEntry(char, entry.uid, new FormData(newRow), false);
 
             selectAltValues.value = newValue;
             selectAltValues.dataset.prevValue = newValue;
@@ -274,8 +275,8 @@ function addStatusRow({data = [], container, template, char}) {
             optionInDisplay.text = inputAltKey.value;
         }, { passive: true });
 
-        newRow.querySelector(".add_alt_value").addEventListener("click", async function () {
-            await updateCharEntry(char, entry.uid, new FormData(newRow), true);
+        newRow.querySelector(".add_alt_value").addEventListener("click", function () {
+            updateCharEntry(char, entry.uid, new FormData(newRow), false);
 
             const newAlt = addCharAltValue(char, entry.uid);
 
@@ -290,7 +291,7 @@ function addStatusRow({data = [], container, template, char}) {
             if (await popupConfirmAction("delete the alt value") === 0) return;
 
             try {
-                await updateCharEntry(char, entry.uid, new FormData(newRow), true);
+                updateCharEntry(char, entry.uid, new FormData(newRow), false);
 
                 const success = removeCharAltValue(char, entry.uid, selectAltValues.value);
 
@@ -746,7 +747,7 @@ export async function popupStatusSingleChar(char) {
 
             for (const form of forms)
                 if (form.dataset.modified === "true")
-                    updateCharEntry(char, form.dataset.uid, new FormData(form));
+                    updateCharEntry(char, form.dataset.uid, new FormData(form), false);
 
             destroyElement(charForm);
         }
@@ -784,7 +785,7 @@ export async function popupStatusMultiChar(chars) {
                 if (!char) continue;
                 if (form.dataset.modified === "false") continue;
 
-                updateCharEntry(char, form.dataset.uid, new FormData(form));
+                updateCharEntry(char, form.dataset.uid, new FormData(form), false);
             }
 
             destroyElement(content);

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -216,8 +216,9 @@ function addStatusRow({data = [], container, template, char}) {
         // @ts-ignore
         if (!entry) return toastr.warning(t`Data for new entry is empty - index=${i}`);
 
-        newRow.dataset.uid = entry.uid;
+        newRow.dataset.uid = String(entry.uid);
         newRow.dataset.charAvatar = char.avatar;
+        newRow.dataset.modified = String(false);
         newRow.removeAttribute('action');
 
         // Set Values
@@ -244,6 +245,10 @@ function addStatusRow({data = [], container, template, char}) {
         if (!entry.enabled) toggleSwitch(newRow, ".kill-switch");
 
         // Add listeners
+        newRow.addEventListener("input", function() {
+            newRow.dataset.modified = String(true);
+        }, { passive: true });
+
         newRow.querySelector(".kill-switch").addEventListener("click", function () {
             const newState = toggleSwitch(newRow, ".kill-switch");
             inputEntryEnabled.value = String(newState);
@@ -740,9 +745,10 @@ export async function popupStatusSingleChar(char) {
             const forms = charFrom.querySelectorAll('form');
 
             for (const form of forms)
-                updateCharEntry(char, form.dataset.uid, new FormData(form));
+                if (form.dataset.modified === "true")
+                    updateCharEntry(char, form.dataset.uid, new FormData(form));
 
-            destroyElement(charFrom)
+            destroyElement(charFrom);
         }
     });
 
@@ -776,11 +782,12 @@ export async function popupStatusMultiChar(chars) {
                 const char = chars.find(char => char.avatar === form.dataset.charAvatar);
 
                 if (!char) continue;
+                if (form.dataset.modified === "false") continue;
 
                 updateCharEntry(char, form.dataset.uid, new FormData(form));
             }
 
-            destroyElement(content)
+            destroyElement(content);
         }
     });
 

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -454,10 +454,11 @@ export function getCharStatusForm(char) {
      * @param {HTMLElement[]?} elements - The title and data-i18n attribute for the button
      * @param {string[]?} classes - Array of class names to add to the button
      * @param {object?} data - Additional data attributes to set on the button
+     * @param {string?} element_type - Type of the HTML element to create
      * @returns {HTMLDivElement} The created button element
      */
-    const createRowWrapper = (elements = [], classes = [], data = {}) => {
-        const row = document.createElement("div");
+    const createRowWrapper = (elements = [], classes = [], data = {}, element_type = "div") => {
+        const row = document.createElement(element_type);
         row.classList.add("d-flex", ...classes);
 
         for (const [key, value] of Object.entries(data))

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -5,7 +5,7 @@ import { t } from "../../../../../i18n.js";
 import { callGenericPopup, POPUP_TYPE } from "../../../../../popup.js";
 import { power_user } from "../../../../../power-user.js";
 import { getSortableDelay } from "../../../../../utils.js";
-import { log, destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
+import { destroyElement, fetchStatusDebounced, extensionSettings } from "../../index.js";
 import { getCharStatus, addCharEntry, removeCharEntry, addCharAltValue, updateCharEntry, getCharAltValue, getCharEntry, removeCharAltValue, refreshCharEntryDisplay, createCharStatus, transferCharStatus, deleteCharStatus, parseValue, saveMetadataSTUM } from "./statusControls.js";
 
 /*  # TODO

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -135,10 +135,197 @@ async function clonePopup(char) {
     return success ? target : false;
 }
 
+/**
+ * Set user clipboard to a stringified version of an object
+ * @param {object} obj - Object to be sent to the clipboard as text
+ * @returns {Promise<void>}
+ */
+function exportObjectToClipboard(obj = {}) {
+    let stringObj = JSON.stringify(obj);
+    stringObj = escapeNewlines(stringObj);
+
+    return copyText(stringObj);
+}
+
 function getFullCharAvatar(status) {
-    // TODO getThumbnailUrl - on next release
-    if (status.is_user) return getThumbnailUrl("persona", status.avatar); //"/thumbnail?type=persona&file=" + status.avatar;
-    else return getThumbnailUrl("avatar", status.avatar); //"/thumbnail?type=avatar&file=" + status.avatar;
+    return getThumbnailUrl(status.is_user ? "persona" : "avatar", status.avatar);
+}
+
+const DEBOUNCE_MS = 400;
+let formDebounceTimer;
+let altKeyDebounceTimer;
+let forceDepthDebounceTimer;
+let separatorDebounceTimer;
+let defEntrySeparatorDebounceTimer;
+let prefixDebounceTimer;
+let suffixDebounceTimer;
+
+/**
+ * @param {HTMLElement} target
+ * @param {string} class_name
+ * @returns {any}
+ */
+function el(target, class_name) {
+    return target.querySelector(class_name);
+}
+
+/** @param {HTMLElement} el */
+function toggleSwitch(el, callback = (param) => {}) {
+    // True if the final state is on
+    const state = !el.classList.contains("fa-toggle-on");
+    el.classList.toggle("fa-toggle-off", !state);
+    el.classList.toggle("fa-toggle-on", state);
+    callback(state);
+};
+
+function refreshAltValues(target, alts, select_uid = 0) {
+    const select = el(target, 'select[name="value_uid"]');
+
+    destroyElement(select.childNodes);
+
+    for (const alt_val of alts) {
+        const option = document.createElement("option");
+        option.value = String(alt_val.uid);
+        option.text = (!alt_val.key ? null : alt_val.key) ?? ("UID " + alt_val.uid);
+
+        if (Number(select_uid) === alt_val.uid) {
+            option.selected = true;
+        }
+
+        select.append(option);
+    }
+};
+
+const evChange = new Event('change', { bubbles: true, cancelable: true });
+const evInput = new Event('input', { bubbles: true, cancelable: true });
+
+function addStatusRow({amount = 1, data = [], container, template, char} = {}) {
+    for (let i = 0; i < amount; i++) {
+        const newRow = /** @type {HTMLFormElement} */ (template.cloneNode(true));
+
+        // @ts-ignore
+        if (!data[i]) return toastr.warning(t`Data for new entry is empty - index=${i}`);
+
+        newRow.dataset.uid = data[i].uid;
+        newRow.removeAttribute('action');
+
+        // Set Values
+        el(newRow, 'input[name="key"]').value = data[i].key;
+        el(newRow, 'input[name="separator"]').value = escapeNewlines(data[i].separator);
+        el(newRow, 'textarea[name="value"]').value = data[i].value;
+        el(newRow, 'input[name="enabled"]').value = data[i].enabled;
+        refreshAltValues(newRow, data[i].alt_values, data[i].value_uid);
+        el(newRow, 'select[name="value_uid"]').value = String(data[i].value_uid);
+        el(newRow, 'input[name="alt_key"]').value = data[i].alt_values.find(alt => alt.uid === data[i].value_uid).key;
+
+        if (!data[i].enabled) toggleSwitch(el(newRow, ".kill-switch"));
+
+        // Add listeners
+        newRow.addEventListener("submit", (e) => {
+            e.preventDefault();
+
+            const formData = new FormData(newRow);
+
+            updateCharEntry(char, data[i].uid, formData);
+        }, { passive: false });
+
+        newRow.addEventListener("input", () => {
+            clearTimeout(formDebounceTimer);
+
+            formDebounceTimer = window.setTimeout(() => newRow.requestSubmit(), DEBOUNCE_MS);
+        }, { passive: true });
+
+        el(newRow, 'select[name="value_uid"]').addEventListener("change", () => {
+            const alt = getCharAltValue(char, data[i].uid, el(newRow, 'select[name="value_uid"]').value);
+
+            el(newRow, 'input[name="alt_key"]').value = alt.key;
+            el(newRow, 'textarea[name="value"]').value = alt.value;
+
+            newRow.dispatchEvent(evInput);
+        }, { passive: true });
+
+        el(newRow, ".delete-row").addEventListener("click", async () => {
+            if (await popupDeleteConfirm("the alt value") === 0) return;
+
+            removeCharEntry(char, data[i].uid);
+            destroyElement(newRow);
+        }, { passive: true });
+
+        el(newRow, ".kill-switch").addEventListener("click", () => {
+            toggleSwitch(el(newRow, ".kill-switch"), (state) => el(newRow, 'input[name="enabled"]').value = state);
+            newRow.requestSubmit();
+        }, { passive: true });
+
+        el(newRow, 'input[name="alt_key"]').addEventListener("keyup", () => {
+            clearTimeout(altKeyDebounceTimer);
+
+            altKeyDebounceTimer = window.setTimeout(() => refreshAltValues(
+                newRow,
+                getCharEntry(char, data[i].uid).alt_values,
+                el(newRow, 'select[name="value_uid"]').value
+            ), DEBOUNCE_MS);
+        }, { passive: true });
+
+        el(newRow, ".add_alt_value").addEventListener("click", () => {
+            const newAlt = addCharAltValue(char, data[i].uid);
+
+            if (!newAlt) return;
+
+            refreshAltValues(newRow, getCharEntry(char, data[i].uid).alt_values, newAlt.uid);
+
+            el(newRow, 'select[name="value_uid"]').value = String(newAlt.uid);
+            el(newRow, 'select[name="value_uid"]').dispatchEvent(evChange);
+        }, { passive: true });
+
+        el(newRow, ".del_alt_value").addEventListener("click", async () => {
+            if (await popupDeleteConfirm("the alt value") === 0) return;
+
+            try {
+                const success = removeCharAltValue(char, data[i].uid, el(newRow, 'select[name="value_uid"]').value);
+
+                if (!success) return;
+
+                const new_alts = getCharEntry(char, data[i].uid).alt_values;
+
+                refreshAltValues(newRow, new_alts);
+
+                el(newRow, 'select[name="value_uid"]').value = String(new_alts[0].uid);
+                el(newRow, 'select[name="value_uid"]').dispatchEvent(evChange);
+            } catch (error) {
+                // ...
+            }
+        }, { passive: true });
+
+        el(newRow, ".menu_button.export").addEventListener("click", async function() {
+            const currentEntry = getCharEntry(char, data[i].uid);
+
+            await exportObjectToClipboard(currentEntry);
+        }, { passive: true });
+
+        newRow.querySelectorAll(".macro_template").forEach((/**@type {HTMLDivElement}*/btn) => {
+            btn.addEventListener("click", async (e) => {
+                const macroType = /**@type {HTMLDivElement}*/(e.currentTarget).dataset.macroType;
+                let macroTemplate = "";
+
+                if (macroType === "text") macroTemplate = "{{text}}";
+                if (macroType === "number") macroTemplate = "{{number}}";
+                if (macroType === "boolean") macroTemplate = "{{boolean::true::true::false}}";
+                if (macroType === "range") macroTemplate = "{{range::0::100::1::0}}";
+
+                if (extensionSettings.altMacroTemplateBehavior) {
+                    const valueTextarea = el(newRow, 'textarea[name="value"]')
+                    valueTextarea.value += macroTemplate;
+                    valueTextarea.dispatchEvent(evInput);
+
+                    return;
+                } else {
+                    await copyText(macroTemplate);
+                }
+            }, { passive: true });
+        });
+
+        container.append(newRow);
+    }
 }
 
 export function getCharStatusForm(char) {
@@ -165,16 +352,6 @@ export function getCharStatusForm(char) {
         return labelTemplate;
     }
 
-    const createButtonsWrapper = (/**@type {HTMLElement[]}*/buttons, lessPadding) => {
-        const buttonsWrapper = document.createElement("div");
-        buttonsWrapper.classList.add("d-flex", "flex-center-start", "buttons-wrapper");
-        buttonsWrapper.append(...buttons);
-
-        if (lessPadding) buttonsWrapper.classList.add("gap-5px");
-
-        return buttonsWrapper;
-    }
-
     /**
      * Creates a button element with specified classes and title.
      * @param {string} title - The title and data-i18n attribute for the button
@@ -192,6 +369,26 @@ export function getCharStatusForm(char) {
             button.dataset[key] = value;
 
         return button;
+    };
+
+    /**
+     * Creates a button element with specified classes and title.
+     * @param {HTMLElement[]?} elements - The title and data-i18n attribute for the button
+     * @param {string[]?} classes - Array of class names to add to the button
+     * @param {object?} data - Additional data attributes to set on the button
+     * @returns {HTMLDivElement} The created button element
+     */
+    const createRowWrapper = (elements = [], classes = [], data = {}) => {
+        const row = document.createElement("div");
+        row.classList.add("d-flex", ...classes);
+
+        for (const [key, value] of Object.entries(data))
+            row.dataset[key] = value;
+
+        for (const elem of elements)
+            row.append(elem);
+
+        return row;
     };
 
     const escapedCharName = lodash.escape(char.name);
@@ -271,38 +468,6 @@ export function getCharStatusForm(char) {
     const compressEntriesBtn = createButton("Compress all entries", ["fa-compress"]);
     const newStatBtn = createButton(`Add an status to ${escapedCharName}`, ["fa-plus"]);
 
-    const statInputsWrapper = document.createElement("div");
-    statInputsWrapper.classList.add("d-flex", "flex-end-start", "w-100", "gap-5px", "stat-wrapper");
-    statInputsWrapper.append(
-        createInputLabel(selectEntryRole),
-        createInputLabel(numberAreaForDepth),
-        createInputLabel(textareaStatusSeparator),
-        createInputLabel(textareaDefEntrySeparator),
-        createInputLabel(textareaStatusPrefix),
-        createInputLabel(textareaStatusSuffix),
-        createButtonsWrapper([
-            deleteStatsBtn,
-            cloneStatsBtn,
-            expandEntriesBtn,
-            compressEntriesBtn,
-            newStatBtn
-        ], true)
-    );
-
-    const contentHeaderWrapper = document.createElement("div");
-    contentHeaderWrapper.classList.add("d-flex", "flex-center-start", "w-100", "py-5px");
-    contentHeaderWrapper.append(
-        avatarContainer,
-        statInputsWrapper
-    );
-
-    const wrapper = document.createElement("div");
-    wrapper.classList.add("d-flex", "flex-col", "flex-start-center", "gap-5px");
-    wrapper.append(
-        charName,
-        contentHeaderWrapper
-    );
-
     /** Create input template */
     /** - Key */
     const dragHandle = document.createElement("span");
@@ -340,18 +505,6 @@ export function getCharStatusForm(char) {
     deleteStatRowBtn.dataset.i18n = "Delete Status entry";
     deleteStatRowBtn.classList.add("menu_button", "fa-fw", "fa-solid", "fa-trash-can", "redWarningBG", "interactable", "delete-row", "big-button");
 
-    const drawerHeader = document.createElement("div");
-    drawerHeader.classList.add("inline-drawer-header", "key", "w-100", "d-flex", "flex-center", "p-0");
-    drawerHeader.append(
-        dragHandle,
-        drawerToggle,
-        enableRowToggle,
-        enableRowBtn,
-        textareaKey,
-        textareaSeparator,
-        deleteStatRowBtn
-    );
-
     /** - Value */
     const selectAltValues = document.createElement("select");
     selectAltValues.ariaPlaceholder = t`Select entry description`;
@@ -370,215 +523,90 @@ export function getCharStatusForm(char) {
     warningAltKey.title = "This is only used in the prompt if description is empty";
     warningAltKey.dataset.i18n = "This is only used in the prompt if description is empty";
 
-    const settingsInputs = document.createElement("div");
-    settingsInputs.classList.add("d-flex", "flex-end-start");
-    settingsInputs.append(
-        createInputLabel(selectAltValues, "mw-25"),
-        createInputLabel(textareaAltKey, "mw-25"),
-        createButtonsWrapper([
-            warningAltKey,
-            createButton("Add alt descriptions", ["big-button", "fa-plus", "add_alt_value"]),
-            createButton("Delete current alt description", ["big-button", "fa-trash-can", "del_alt_value", "redWarningBG"]),
-            createButton("Add template for text macro", ["big-button", "fa-t", "macro_template", "px-5px"], {macroType: "text"}),
-            createButton("Add template for number macro", ["big-button", "fa-n", "macro_template", "px-5px"], {macroType: "number"}),
-            createButton("Add template for boolean macro", ["big-button", "fa-b", "macro_template", "px-5px"], {macroType: "boolean"}),
-            createButton("Add template for range macro", ["big-button", "fa-r", "macro_template", "px-5px"], {macroType: "range"}),
-        ])
-    );
-
     const textareaValue = document.createElement("textarea");
     textareaValue.name = "value";
     textareaValue.placeholder = t`Entry description...`;
     textareaValue.classList.add("text_pole", "m-0");
 
-    const drawerContentContainer = document.createElement("div");
-    drawerContentContainer.classList.add("d-flex", "flex-col");
-    drawerContentContainer.append(settingsInputs, textareaValue);
+    /** - Key/Value Block */
+    const entryBodyToolButtons = createRowWrapper([
+        warningAltKey,
+        createButton("Add alt descriptions", ["big-button", "fa-plus", "add_alt_value"]),
+        createButton("Delete current alt description", ["big-button", "fa-trash-can", "del_alt_value", "redWarningBG"]),
+        createButton("Import entry from clipboard", ["big-button", "fa-arrow-right-to-file", "import", "px-5px"]),
+        createButton("Export entry from clipboard", ["big-button", "fa-arrow-right-from-file", "export", "px-5px"]),
+        createButton("Add template for text macro", ["big-button", "fa-t", "macro_template", "px-5px"], {macroType: "text"}),
+        createButton("Add template for number macro", ["big-button", "fa-n", "macro_template", "px-5px"], {macroType: "number"}),
+        createButton("Add template for boolean macro", ["big-button", "fa-b", "macro_template", "px-5px"], {macroType: "boolean"}),
+        createButton("Add template for range macro", ["big-button", "fa-r", "macro_template", "px-5px"], {macroType: "range"}),
+    ], ["flex-center-start", "buttons-wrapper"]);
+
+    const entryBodyToolbar = createRowWrapper([
+        createInputLabel(selectAltValues, "mw-25"),
+        createInputLabel(textareaAltKey, "mw-25"),
+        entryBodyToolButtons
+    ], ["flex-end-start"])
 
     const drawerContent = document.createElement("div");
     drawerContent.classList.add("inline-drawer-content", "value", "w-100", "p-0", "mb-5px");
-    drawerContent.append(drawerContentContainer);
+    drawerContent.append(
+        createRowWrapper([
+            entryBodyToolbar,
+            textareaValue
+        ], ["flex-col"])
+    );
 
-    /** - Key/Value Block */
     const formRow = document.createElement("form");
     formRow.classList.add("stat-us-max-popup-row", "d-flex", "flex-col", "inline-drawer");
-    formRow.append(drawerHeader, drawerContent);
+    formRow.append(
+        createRowWrapper([ // Drawer Header
+            dragHandle,
+            drawerToggle,
+            enableRowToggle,
+            enableRowBtn,
+            textareaKey,
+            textareaSeparator,
+            deleteStatRowBtn
+        ], ["inline-drawer-header", "key", "w-100", "flex-center", "p-0"]),
+        drawerContent // Drawer Body
+    );
 
     /** Create Menu container and assemble Menu */
-    const content = document.createElement("div");
-    content.classList.add("d-flex", "flex-col", "gap-5px", "pt-5px");
+    const statusHeaderButtons = createRowWrapper([
+        deleteStatsBtn,
+        cloneStatsBtn,
+        expandEntriesBtn,
+        compressEntriesBtn,
+        newStatBtn
+    ], ["gap-5px", "flex-center-start", "buttons-wrapper"]);
 
-    const container = document.createElement("div");
-    container.dataset.char = metadata.avatar;
-    container.dataset.isUser = metadata.is_user;
-    container.classList.add("stat-us-max-popup");
-    container.append(wrapper, content);
+    const statusHeaderInputs = createRowWrapper([
+        createInputLabel(selectEntryRole),
+        createInputLabel(numberAreaForDepth),
+        createInputLabel(textareaStatusSeparator),
+        createInputLabel(textareaDefEntrySeparator),
+        createInputLabel(textareaStatusPrefix),
+        createInputLabel(textareaStatusSuffix),
+        statusHeaderButtons
+    ], ["flex-end-start", "w-100", "gap-5px", "stat-wrapper"]);
+
+    const statusHeaderForm = createRowWrapper([
+        avatarContainer,
+        statusHeaderInputs
+    ], ["flex-center-start", "w-100", "py-5px"]);
+
+    const statusHeader = createRowWrapper([
+        charName,
+        statusHeaderForm
+    ], ["flex-col", "flex-start-center", "gap-5px"]);
+
+    const content = createRowWrapper(undefined, ["flex-col", "gap-5px", "pt-5px"]);
+    const container = createRowWrapper([
+        statusHeader,
+        content
+    ], ["stat-us-max-popup", "flex-col"], {char: metadata.avatar, isUser: metadata.is_user});
 
     /** Add listeners */
-    const DEBOUNCE_MS = 400;
-    let formDebounceTimer;
-    let altKeyDebounceTimer;
-    let forceDepthDebounceTimer;
-    let separatorDebounceTimer;
-    let defEntrySeparatorDebounceTimer;
-    let prefixDebounceTimer;
-    let suffixDebounceTimer;
-
-    const el = (target, class_name) => target.querySelector(class_name);
-
-    /** @param {HTMLElement} el */
-    const toggleSwitch = (el, callback = (param) => {}) => {
-        // True if the final state is on
-        const state = !el.classList.contains("fa-toggle-on");
-        el.classList.toggle("fa-toggle-off", !state);
-        el.classList.toggle("fa-toggle-on", state);
-        callback(state);
-    };
-
-    const refreshAltValues = (target, alts, select_uid = 0) => {
-        const select = el(target, 'select[name="value_uid"]');
-
-        destroyElement(select.childNodes);
-
-        for (const alt_val of alts) {
-            const option = document.createElement("option");
-            option.value = String(alt_val.uid);
-            option.text = (!alt_val.key ? null : alt_val.key) ?? ("UID " + alt_val.uid);
-
-            if (Number(select_uid) === alt_val.uid) {
-                option.selected = true;
-            }
-
-            select.append(option);
-        }
-    };
-
-    const evChange = new Event('change', { bubbles: true, cancelable: true });
-    const evInput = new Event('input', { bubbles: true, cancelable: true });
-
-    const addRow = ({amount = 1, data = []} = {}) => {
-        for (let i = 0; i < amount; i++) {
-            const newRow = /** @type {HTMLFormElement} */ (formRow.cloneNode(true));
-
-            // @ts-ignore
-            if (!data[i]) return toastr.warning(t`Data for new entry is empty - index=${i}`);
-
-            newRow.dataset.uid = data[i].uid;
-            newRow.removeAttribute('action');
-
-            // Set Values
-            el(newRow, 'input[name="key"]').value = data[i].key;
-            el(newRow, 'input[name="separator"]').value = escapeNewlines(data[i].separator);
-            el(newRow, 'textarea[name="value"]').value = data[i].value;
-            el(newRow, 'input[name="enabled"]').value = data[i].enabled;
-            refreshAltValues(newRow, data[i].alt_values, data[i].value_uid);
-            el(newRow, 'select[name="value_uid"]').value = String(data[i].value_uid);
-            el(newRow, 'input[name="alt_key"]').value = data[i].alt_values.find(alt => alt.uid === data[i].value_uid).key;
-
-            if (!data[i].enabled) toggleSwitch(el(newRow, ".kill-switch"));
-
-            // Add listeners
-            newRow.addEventListener("submit", (e) => {
-                e.preventDefault();
-
-                const formData = new FormData(newRow);
-
-                updateCharEntry(char, data[i].uid, formData);
-            }, { passive: false });
-
-            newRow.addEventListener("input", () => {
-                clearTimeout(formDebounceTimer);
-
-                formDebounceTimer = window.setTimeout(() => newRow.requestSubmit(), DEBOUNCE_MS);
-            }, { passive: true });
-
-            el(newRow, 'select[name="value_uid"]').addEventListener("change", () => {
-                const alt = getCharAltValue(char, data[i].uid, el(newRow, 'select[name="value_uid"]').value);
-
-                el(newRow, 'input[name="alt_key"]').value = alt.key;
-                el(newRow, 'textarea[name="value"]').value = alt.value;
-
-                newRow.dispatchEvent(evInput);
-            }, { passive: true });
-
-            el(newRow, ".delete-row").addEventListener("click", async () => {
-                if (await popupDeleteConfirm("the alt value") === 0) return;
-
-                removeCharEntry(char, data[i].uid);
-                destroyElement(newRow);
-            }, { passive: true });
-
-            el(newRow, ".kill-switch").addEventListener("click", () => {
-                toggleSwitch(el(newRow, ".kill-switch"), (state) => el(newRow, 'input[name="enabled"]').value = state);
-                newRow.requestSubmit();
-            }, { passive: true });
-
-            el(newRow, 'input[name="alt_key"]').addEventListener("keyup", () => {
-                clearTimeout(altKeyDebounceTimer);
-
-                altKeyDebounceTimer = window.setTimeout(() => refreshAltValues(
-                    newRow,
-                    getCharEntry(char, data[i].uid).alt_values,
-                    el(newRow, 'select[name="value_uid"]').value
-                ), DEBOUNCE_MS);
-            }, { passive: true });
-
-            el(newRow, ".add_alt_value").addEventListener("click", () => {
-                const newAlt = addCharAltValue(char, data[i].uid);
-
-                if (!newAlt) return;
-
-                refreshAltValues(newRow, getCharEntry(char, data[i].uid).alt_values, newAlt.uid);
-
-                el(newRow, 'select[name="value_uid"]').value = String(newAlt.uid);
-                el(newRow, 'select[name="value_uid"]').dispatchEvent(evChange);
-            }, { passive: true });
-
-            el(newRow, ".del_alt_value").addEventListener("click", async () => {
-                if (await popupDeleteConfirm("the alt value") === 0) return;
-
-                try {
-                    const success = removeCharAltValue(char, data[i].uid, el(newRow, 'select[name="value_uid"]').value);
-
-                    if (!success) return;
-
-                    const new_alts = getCharEntry(char, data[i].uid).alt_values;
-
-                    refreshAltValues(newRow, new_alts);
-
-                    el(newRow, 'select[name="value_uid"]').value = String(new_alts[0].uid);
-                    el(newRow, 'select[name="value_uid"]').dispatchEvent(evChange);
-                } catch (error) {
-                    // ...
-                }
-            }, { passive: true });
-
-            newRow.querySelectorAll(".macro_template").forEach((/**@type {HTMLDivElement}*/btn) => {
-                btn.addEventListener("click", (e) => {
-                    const macroType = /**@type {HTMLDivElement}*/(e.currentTarget).dataset.macroType;
-                    let macroTemplate = "";
-
-                    if (macroType === "text") macroTemplate = "{{text}}";
-                    if (macroType === "number") macroTemplate = "{{number}}";
-                    if (macroType === "boolean") macroTemplate = "{{boolean::true::true::false}}";
-                    if (macroType === "range") macroTemplate = "{{range::0::100::1::0}}";
-
-                    if (extensionSettings.altMacroTemplateBehavior) {
-                        const valueTextarea = el(newRow, 'textarea[name="value"]')
-                        valueTextarea.value += macroTemplate;
-                        valueTextarea.dispatchEvent(evInput);
-
-                        return;
-                    } else {
-                        copyText(macroTemplate);
-                    }
-                }, { passive: true });
-            });
-
-            content.append(newRow);
-        }
-    }
-
     expandEntriesBtn.addEventListener("click", () =>
         content.querySelectorAll(".inline-drawer-toggle.down").forEach((/**@type {HTMLElement}*/toggle) => toggle.click())
     , { passive: true });
@@ -589,7 +617,12 @@ export function getCharStatusForm(char) {
 
     newStatBtn.addEventListener("click", () => {
         const newEntry = addCharEntry(char, "", "");
-        addRow({data: [newEntry]});
+        addStatusRow({
+            data: [newEntry],
+            container: content,
+            template: formRow,
+            char: char
+        });
     }, { passive: true });
 
     selectEntryRole.addEventListener("input", () => {
@@ -682,20 +715,26 @@ export function getCharStatusForm(char) {
         }
     }, { passive: true });
 
+    /** Add def rows */
+    if (metadata.entries.length > 0) addStatusRow({
+        amount: metadata.entries.length,
+        data: metadata.entries,
+        container: content,
+        template: formRow,
+        char: char
+    });
+
     // @ts-ignore
     $(content).sortable({
         items: '.stat-us-max-popup-row',
         delay: getSortableDelay(),
         handle: '.drag-handle',
-        stop: async function (_event, _ui) {
+        stop: function (_event, _ui) {
             const forms = content.querySelectorAll("form");
 
             refreshCharEntryDisplay(char, forms);
         },
     });
-
-    /** Add def rows */
-    if (metadata.entries.length > 0) addRow({amount: metadata.entries.length, data: metadata.entries});
 
     return container;
 }

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -454,15 +454,9 @@ function commandCreateEntryAltValue(args, value = "") {
         if (!character) throw new Error(`The character "${char}" could not be found in the metadata`);
         if (isNaN(parsed_uid) || parsed_uid < 0) throw new Error(`Invalid UID "${uid}"`);
 
-        const alt = addCharAltValue(character, parsed_uid, String(value));
+        const alt = addCharAltValue(character, parsed_uid, {value: String(value), key: String(key)});
 
         if (!alt) return "";
-        if (Boolean(key)) {
-            const formData = new FormData();
-            formData.set("key", key);
-
-            updateCharAltValue(character, parsed_uid, alt.uid, formData);
-        }
 
         fetchStatusDebounced({forceUIUpdate: true});
 

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -8,8 +8,8 @@ import { commonEnumProviders, enumIcons } from "../../../../../slash-commands/Sl
 import { enumTypes, SlashCommandEnumValue } from "../../../../../slash-commands/SlashCommandEnumValue.js";
 import { SlashCommandExecutor } from "../../../../../slash-commands/SlashCommandExecutor.js";
 import { SlashCommandParser } from "../../../../../slash-commands/SlashCommandParser.js";
-import { fetchStatusDebounced, getParticipant, log } from "../../index.js";
-import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, saveMetadataSTUM, updateCharAltValue, updateCharEntry, updateCharStatus } from "./statusControls.js";
+import { fetchStatusDebounced, getParticipant } from "../../index.js";
+import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, updateCharAltValue, updateCharEntry, updateCharStatus } from "./statusControls.js";
 
 /*  # TODO
     - [X] Command to create Status data
@@ -636,7 +636,7 @@ function commandDeleteAltEntry(args, value) {
 async function commandDeleteChatStatus() {
     try {
         delete SillyTavern.getContext().chatMetadata.stat_us_maximus;
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
     } catch (error) {
         return "false";
     }

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -424,7 +424,7 @@ function commandSwitchEntryValue(args, value) {
         formData.set("value", alt.value);
         formData.set("value_uid", alt.uid);
 
-        updateCharEntry(character, parsed_uid, formData);
+        updateCharEntry(character, parsed_uid, formData, false);
         fetchStatusDebounced({forceUIUpdate: true});
 
         return "";
@@ -636,7 +636,7 @@ function commandDeleteAltEntry(args, value) {
 async function commandDeleteChatStatus() {
     try {
         delete SillyTavern.getContext().chatMetadata.stat_us_maximus;
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
     } catch (error) {
         return "false";
     }

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -8,7 +8,7 @@ import { commonEnumProviders, enumIcons } from "../../../../../slash-commands/Sl
 import { enumTypes, SlashCommandEnumValue } from "../../../../../slash-commands/SlashCommandEnumValue.js";
 import { SlashCommandExecutor } from "../../../../../slash-commands/SlashCommandExecutor.js";
 import { SlashCommandParser } from "../../../../../slash-commands/SlashCommandParser.js";
-import { fetchStatusDebounced, getParticipant } from "../../index.js";
+import { fetchStatusDebounced, getParticipant, setSaveStateFlag } from "../../index.js";
 import { addCharAltValue, addCharEntry, createCharStatus, deleteCharStatus, fillMissingMetadata, getCharAltValue, getCharEntry, getCharStatus, removeCharAltValue, removeCharEntry, updateCharAltValue, updateCharEntry, updateCharStatus } from "./statusControls.js";
 
 /*  # TODO
@@ -630,6 +630,7 @@ function commandDeleteAltEntry(args, value) {
 async function commandDeleteChatStatus() {
     try {
         delete SillyTavern.getContext().chatMetadata.stat_us_maximus;
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
     } catch (error) {
         return "false";

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -1,4 +1,4 @@
-import { deleteCharTracker, log } from "../../index.js";
+import { deleteCharTracker } from "../../index.js";
 import { chat, chat_metadata, extension_prompt_roles } from "../../../../../../script.js";
 import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { t } from "../../../../../i18n.js";

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -497,6 +497,55 @@ const altEntryTemplate = {
     value: ""
 };
 
+export function evaluateEntry(entryObj) {
+    for (const key of Object.keys(entryTemplate)) {
+        if (key === 'uid' || key === 'display_position') continue;
+
+        if (entryObj[key] === undefined) {
+            toastr.warning(t`Wrong metadata: key ${key} is missing`);
+            return false;
+        }
+    }
+
+    for (const [k, v] of Object.entries(entryObj)) {
+        if (k === 'uid' || k === 'display_position') continue;
+
+        if (entryTemplate[k] === undefined) {
+            delete entryObj[k];
+            continue;
+        }
+
+        const realEntryType = typeof entryTemplate[k];
+        const entryObjType = typeof v;
+
+        if (realEntryType !== entryObjType) {
+            toastr.warning(t`Wrong metadata: value type of key ${k} is ${entryObjType}, ${realEntryType} expected`);
+            return false;
+        }
+    }
+
+    for (const alt of entryObj.alt_values) {
+        for (const [k, v] of Object.entries(alt)) {
+            if (k === 'uid') continue;
+
+            if (altEntryTemplate[k] === undefined) {
+                delete alt[k];
+                continue;
+            }
+
+            const realAltType = typeof altEntryTemplate[k];
+            const entryObjAltType = typeof v;
+
+            if (realAltType !== entryObjAltType) {
+                toastr.warning(t`Wrong metadata: value type of key ${k} in alt entry is ${entryObjAltType}, ${realAltType} expected`);
+                return false;
+            }
+        }
+    }
+    
+    return true;
+}
+
 /** I hate this code */
 export async function fillMissingMetadata() {
     try {

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -26,7 +26,7 @@ export function getLastDisplayPosition(data) {
     return data.length;
 }
 
-export function addCharAltValue(character, entry_uid, alt_value = "") {
+export function addCharAltValue(character, entry_uid, {value = "", key = ""} = {}) {
     try {
         const entry = getCharEntry(character, entry_uid);
 
@@ -34,8 +34,8 @@ export function addCharAltValue(character, entry_uid, alt_value = "") {
 
         const newAlt = {
             uid: getFreeDataUid(entry.alt_values),
-            key: "",
-            value: alt_value
+            key: key,
+            value: value
         };
 
         entry.alt_values.push(newAlt);
@@ -125,6 +125,29 @@ export function removeCharAltValue(character, entry_uid, alt_uid) {
     } catch (error) {
         // @ts-ignore
         toastr.error(t`Failed to delete Status Metadata: ${error.message}`);
+        console.error(error.message);
+
+        return false;
+    }
+}
+
+export function flushCharAltValues(character, entry_uid, silent = false) {
+    try {
+        const entry = getCharEntry(character, entry_uid);
+
+        if (!entry) throw new Error(`Entry with uid=${entry_uid} could not be found`);
+        if (entry.alt_values.length <= 1) throw new Error("There are no more alt descriptions to delete");
+
+        
+        entry.alt_values = entry.alt_values.filter(alt => alt.uid === entry.value_uid);
+        const remainingAlt = entry.alt_values[0];
+
+        entry.value = remainingAlt.value;
+        entry.value_uid = remainingAlt.uid;
+
+        return true;
+    } catch (error) {
+        if (!silent) toastr.error(t`Failed to delete Status Metadata: ${error.message}`);
         console.error(error.message);
 
         return false;

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -232,9 +232,10 @@ export function parseValue(val) {
     @param {object} character
     @param {Number|String} entry_uid
     @param {FormData} formData
-    @returns {object|Boolean}
+    @param {boolean?} doAwait
+    @returns {Promise} Entry object or false
 */
-export function updateCharEntry(character, entry_uid, formData) {
+export async function updateCharEntry(character, entry_uid, formData, doAwait = false) {
     try {
         const entry = getCharEntry(character, entry_uid);
 
@@ -258,7 +259,8 @@ export function updateCharEntry(character, entry_uid, formData) {
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        if (doAwait) await SillyTavern.getContext().saveMetadata();
+        else SillyTavern.getContext().saveMetadataDebounced();
 
         return entry;
     } catch (error) {
@@ -281,7 +283,7 @@ export function removeCharEntry(character, entry_uid = -1) {
 
         char_status.entries = char_status
             .entries
-            .filter(s => s.uid !== Number(entry_uid));
+            .filter(entry => entry.uid !== Number(entry_uid));
 
         getLastDisplayPosition(char_status.entries);
         SillyTavern.getContext().saveMetadataDebounced();

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -40,7 +40,7 @@ export function addCharAltValue(character, entry_uid, alt_value = "") {
 
         entry.alt_values.push(newAlt);
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return newAlt;
     } catch (error) {
@@ -91,7 +91,7 @@ export function updateCharAltValue(character, entry_uid, alt_uid, formData) {
 
         if (entry.value_uid === alt.uid) entry.value = alt.value;
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return alt;
     } catch (error) {
@@ -108,7 +108,7 @@ export function removeCharAltValue(character, entry_uid, alt_uid) {
         const entry = getCharEntry(character, entry_uid);
 
         if (!entry) throw new Error(`Entry with uid=${entry_uid} could not be found`);
-        if (entry.alt_values.length <= 1) throw new Error("You can't delete all alt descriptions");
+        if (entry.alt_values.length <= 1) throw new Error("There are no more alt descriptions to delete");
 
         entry.alt_values = entry
             .alt_values
@@ -119,7 +119,7 @@ export function removeCharAltValue(character, entry_uid, alt_uid) {
             entry.value_uid = entry.alt_values[0].uid;
         }
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
@@ -156,7 +156,7 @@ export function addCharEntry(character, entry_key = "", entry_value = "") {
 
         char_status.entries.push(newEntry);
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return newEntry;
     } catch (error) {
@@ -188,7 +188,7 @@ export function refreshCharEntryDisplay(character, display_order) {
 
         char_status.entries = ordered_data;
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
     } catch (error) {
         // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
@@ -232,10 +232,10 @@ export function parseValue(val) {
     @param {object} character
     @param {Number|String} entry_uid
     @param {FormData} formData
-    @param {boolean?} doAwait
+    @param {boolean?} doSaveData
     @returns {Promise} Entry object or false
 */
-export async function updateCharEntry(character, entry_uid, formData, doAwait = false) {
+export async function updateCharEntry(character, entry_uid, formData, doSaveData = true) {
     try {
         const entry = getCharEntry(character, entry_uid);
 
@@ -259,8 +259,7 @@ export async function updateCharEntry(character, entry_uid, formData, doAwait = 
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
-        if (doAwait) await SillyTavern.getContext().saveMetadata();
-        else SillyTavern.getContext().saveMetadataDebounced();
+        if (doSaveData) SillyTavern.getContext().saveChat();
 
         return entry;
     } catch (error) {
@@ -286,7 +285,7 @@ export function removeCharEntry(character, entry_uid = -1) {
             .filter(entry => entry.uid !== Number(entry_uid));
 
         getLastDisplayPosition(char_status.entries);
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
@@ -317,7 +316,7 @@ export function createCharStatus(character, depth = -1) {
 
         chat_metadata.stat_us_maximus.push(status);
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return status;
     } catch (error) {
@@ -360,7 +359,7 @@ export function updateCharStatus(character, formData) {
             status[key] = parsedValue;
         }
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return status;
     } catch (error) {
@@ -411,7 +410,7 @@ export function transferCharStatus(character, target, {deleteOriginal = false, o
 
         if (deleteOriginal) deleteCharStatus(character);
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
@@ -430,7 +429,7 @@ export function deleteCharStatus(character) {
         chat_metadata.stat_us_maximus = chat_metadata.stat_us_maximus
             .filter(stat => stat.avatar !== character.avatar);
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
         deleteCharTracker(character);
 
         return true;
@@ -498,7 +497,7 @@ export async function fillMissingMetadata() {
             }
         }
 
-        SillyTavern.getContext().saveMetadataDebounced();
+        SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -1,4 +1,4 @@
-import { deleteCharTracker } from "../../index.js";
+import { deleteCharTracker, setSaveStateFlag } from "../../index.js";
 import { chat, chat_metadata, extension_prompt_roles } from "../../../../../../script.js";
 import { t } from "../../../../../i18n.js";
 import { un_escapeNewlines } from "./popups.js";
@@ -282,6 +282,7 @@ export async function updateCharEntry(character, entry_uid, formData, doSaveData
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
+        setSaveStateFlag(doSaveData);
         if (doSaveData) SillyTavern.getContext().saveChat();
 
         return entry;

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -292,8 +292,8 @@ export async function updateCharEntry(character, entry_uid, formData, doSaveData
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
-        setSaveStateFlag(extensionSettings.autoSaveMetadata === true || doSaveData);
-        if (extensionSettings.autoSaveMetadata === true || doSaveData) SillyTavern.getContext().saveChat();
+        setSaveStateFlag(extensionSettings.autoSaveMetadata || doSaveData);
+        if (extensionSettings.autoSaveMetadata || doSaveData) SillyTavern.getContext().saveChat();
 
         return entry;
     } catch (error) {

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -3,6 +3,18 @@ import { chat, chat_metadata, extension_prompt_roles } from "../../../../../../s
 import { t } from "../../../../../i18n.js";
 import { un_escapeNewlines } from "./popups.js";
 
+/** @type {Function} */
+toastr.error
+
+/** @type {Function} */
+toastr.warning
+
+/** @type {Function} */
+toastr.info
+
+/** @type {Function} */
+toastr.success
+
 export function getFreeDataUid(data) {
     if (!data?.length) return 0;
 
@@ -40,11 +52,11 @@ export function addCharAltValue(character, entry_uid, {value = "", key = ""} = {
 
         entry.alt_values.push(newAlt);
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return newAlt;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -66,7 +78,6 @@ export function getCharAltValue(character, entry_uid, alt_uid) {
 
         return alt;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -91,11 +102,11 @@ export function updateCharAltValue(character, entry_uid, alt_uid, formData) {
 
         if (entry.value_uid === alt.uid) entry.value = alt.value;
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return alt;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -119,11 +130,11 @@ export function removeCharAltValue(character, entry_uid, alt_uid) {
             entry.value_uid = entry.alt_values[0].uid;
         }
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to delete Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -179,11 +190,11 @@ export function addCharEntry(character, entry_key = "", entry_value = "") {
 
         char_status.entries.push(newEntry);
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return newEntry;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -211,9 +222,9 @@ export function refreshCharEntryDisplay(character, display_order) {
 
         char_status.entries = ordered_data;
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
     }
@@ -233,7 +244,6 @@ export function getCharEntry(character, entry_uid) {
 
         return entry;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -287,7 +297,6 @@ export async function updateCharEntry(character, entry_uid, formData, doSaveData
 
         return entry;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -309,11 +318,11 @@ export function removeCharEntry(character, entry_uid = -1) {
             .filter(entry => entry.uid !== Number(entry_uid));
 
         getLastDisplayPosition(char_status.entries);
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to delete Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -340,11 +349,11 @@ export function createCharStatus(character, depth = -1) {
 
         chat_metadata.stat_us_maximus.push(status);
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return status;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to create Status Metadata - Check the browser console for more details`);
         console.error(error);
 
@@ -383,11 +392,11 @@ export function updateCharStatus(character, formData) {
             status[key] = parsedValue;
         }
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return status;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
         console.error(error.message);
 
@@ -434,11 +443,11 @@ export function transferCharStatus(character, target, {deleteOriginal = false, o
 
         if (deleteOriginal) deleteCharStatus(character);
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to transfer Status Metadata - Check the browser console for more details`);
         console.error(error);
 
@@ -453,12 +462,12 @@ export function deleteCharStatus(character) {
         chat_metadata.stat_us_maximus = chat_metadata.stat_us_maximus
             .filter(stat => stat.avatar !== character.avatar);
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
         deleteCharTracker(character);
 
         return true;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to delete Status Metadata - Check the browser console for more details`);
         console.error(error);
 
@@ -570,11 +579,11 @@ export async function fillMissingMetadata() {
             }
         }
 
+        setSaveStateFlag(true);
         SillyTavern.getContext().saveChat();
 
         return true;
     } catch (error) {
-        // @ts-ignore
         toastr.error(t`Failed to fill Status Metadata: ${error.message}`);
         console.error(error.message);
 

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -1,16 +1,7 @@
 import { deleteCharTracker } from "../../index.js";
 import { chat, chat_metadata, extension_prompt_roles } from "../../../../../../script.js";
-import { saveMetadataDebounced } from "../../../../../extensions.js";
 import { t } from "../../../../../i18n.js";
 import { un_escapeNewlines } from "./popups.js";
-
-let saveDataTimeout;
-const SAVE_DATA_TIMEOUT_MS = 300;
-
-export function saveMetadataSTUM() {
-    clearTimeout(saveDataTimeout)
-    saveDataTimeout = setTimeout(saveMetadataDebounced, SAVE_DATA_TIMEOUT_MS);
-}
 
 export function getFreeDataUid(data) {
     if (!data?.length) return 0;
@@ -49,7 +40,7 @@ export function addCharAltValue(character, entry_uid, alt_value = "") {
 
         entry.alt_values.push(newAlt);
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return newAlt;
     } catch (error) {
@@ -100,7 +91,7 @@ export function updateCharAltValue(character, entry_uid, alt_uid, formData) {
 
         if (entry.value_uid === alt.uid) entry.value = alt.value;
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return alt;
     } catch (error) {
@@ -128,7 +119,7 @@ export function removeCharAltValue(character, entry_uid, alt_uid) {
             entry.value_uid = entry.alt_values[0].uid;
         }
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return true;
     } catch (error) {
@@ -165,7 +156,7 @@ export function addCharEntry(character, entry_key = "", entry_value = "") {
 
         char_status.entries.push(newEntry);
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return newEntry;
     } catch (error) {
@@ -197,7 +188,7 @@ export function refreshCharEntryDisplay(character, display_order) {
 
         char_status.entries = ordered_data;
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
     } catch (error) {
         // @ts-ignore
         toastr.error(t`Failed to save Status Metadata: ${error.message}`);
@@ -267,7 +258,7 @@ export function updateCharEntry(character, entry_uid, formData) {
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return entry;
     } catch (error) {
@@ -293,7 +284,7 @@ export function removeCharEntry(character, entry_uid = -1) {
             .filter(s => s.uid !== Number(entry_uid));
 
         getLastDisplayPosition(char_status.entries);
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return true;
     } catch (error) {
@@ -324,7 +315,7 @@ export function createCharStatus(character, depth = -1) {
 
         chat_metadata.stat_us_maximus.push(status);
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return status;
     } catch (error) {
@@ -367,7 +358,7 @@ export function updateCharStatus(character, formData) {
             status[key] = parsedValue;
         }
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return status;
     } catch (error) {
@@ -418,7 +409,7 @@ export function transferCharStatus(character, target, {deleteOriginal = false, o
 
         if (deleteOriginal) deleteCharStatus(character);
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return true;
     } catch (error) {
@@ -437,7 +428,7 @@ export function deleteCharStatus(character) {
         chat_metadata.stat_us_maximus = chat_metadata.stat_us_maximus
             .filter(stat => stat.avatar !== character.avatar);
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
         deleteCharTracker(character);
 
         return true;
@@ -505,7 +496,7 @@ export async function fillMissingMetadata() {
             }
         }
 
-        saveMetadataSTUM();
+        SillyTavern.getContext().saveMetadataDebounced();
 
         return true;
     } catch (error) {

--- a/source/js/statusControls.js
+++ b/source/js/statusControls.js
@@ -1,4 +1,4 @@
-import { deleteCharTracker, setSaveStateFlag } from "../../index.js";
+import { deleteCharTracker, extensionSettings, setSaveStateFlag } from "../../index.js";
 import { chat, chat_metadata, extension_prompt_roles } from "../../../../../../script.js";
 import { t } from "../../../../../i18n.js";
 import { un_escapeNewlines } from "./popups.js";
@@ -292,8 +292,8 @@ export async function updateCharEntry(character, entry_uid, formData, doSaveData
         altValue.value = entry.value;
         altValue.key = formData.get("alt_key") ?? altValue.key;
 
-        setSaveStateFlag(doSaveData);
-        if (doSaveData) SillyTavern.getContext().saveChat();
+        setSaveStateFlag(extensionSettings.autoSaveMetadata === true || doSaveData);
+        if (extensionSettings.autoSaveMetadata === true || doSaveData) SillyTavern.getContext().saveChat();
 
         return entry;
     } catch (error) {

--- a/style.css
+++ b/style.css
@@ -597,6 +597,11 @@ div[name="templatesAndPopupsWrapper"] {
     .text-line .value {
         white-space: break-spaces;
     }
+    
+    .text-line .value[data-empty]::after {
+        content: "...";
+        color: color-mix(in srgb, var(--SmartThemeQuoteColor) 50%, transparent);
+    }
 
     .text-quote:has(~ input[type="range"]):hover {
         cursor: pointer;

--- a/style.css
+++ b/style.css
@@ -150,7 +150,6 @@ div[name="templatesAndPopupsWrapper"] {
     --stat-us-border-color: var(--SmartThemeBorderColor);
     --stat-us-avatar-height: var(--avatar-base-height);
     --stat-us-avatar-border-radius: 50%;
-    --stat-us-range-margin-top: 5px;
     --stat-us-separator-bottom: linear-gradient(90deg, var(--transparent), color-mix(in srgb, var(--SmartThemeBodyColor), transparent 80%), var(--transparent)) 1;
     --stat-us-show-spaces-color: color-mix(in srgb, var(--SmartThemeBotMesBlurTintColor), var(--SmartThemeQuoteColor) 12%);
 
@@ -595,22 +594,20 @@ div[name="templatesAndPopupsWrapper"] {
         white-space: break-spaces;
     }
 
-    span.chat-input-editor {
+    .text-quote:has(~ input[type="range"]):hover {
+        cursor: pointer;
+    }
+
+    input[type="range"].chat-input-editor {
         display: inline-flex;
         vertical-align: middle;
         min-width: 5ch;
         width: var(--stum-range-input-width);
         max-width: unset;
+    }
 
-        input[type="range"] {
-            margin-top: var(--stat-us-range-margin-top) !important;
-        }
-
-        input[type="number"] {
-            padding: 2px 5px 0;
-            font-family: monospace;
-            border: unset;
-        }
+    input[type="range"].chat-input-editor:focus {
+        background: var(--SmartThemeQuoteColor);
     }
 
     .input-label {

--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
 :root {
     --stum-input-label-display: block;
     --stum-range-input-width: auto;
+    --stum-save-state-color: transparent;
 }
 
 #stat-us-max-settings-window div.flex-container.flex-column,
@@ -628,5 +629,9 @@ div[name="templatesAndPopupsWrapper"] {
         z-index: 40;
         overflow-y: scroll;
         max-height: 15vh;
+    }
+
+    .menu_button.fa-floppy-disk {
+        background-color: var(--stum-save-state-color);
     }
 }

--- a/style.css
+++ b/style.css
@@ -81,6 +81,7 @@ div[name="templatesAndPopupsWrapper"] {
 .popup:has(.stat-us-max-popup) {
     background-color: var(--SmartThemeBotMesBlurTintColor);
     border-color: var(--stat-us-border-color) !important;
+    width: 90vw;
 }
 
 #stat-us-max-popup-multi-char {

--- a/style.css
+++ b/style.css
@@ -604,6 +604,8 @@ div[name="templatesAndPopupsWrapper"] {
         min-width: 5ch;
         width: var(--stum-range-input-width);
         max-width: unset;
+        height: 1ch;
+        border-radius: 5px !important;
     }
 
     input[type="range"].chat-input-editor:focus {

--- a/style.css
+++ b/style.css
@@ -361,6 +361,10 @@ div[name="templatesAndPopupsWrapper"] {
 
     .disabled {
         color: color-mix(in srgb, currentColor 40%, black);
+
+        .text-line {
+            pointer-events: none;
+        }
     }
 
     .w-auto {

--- a/style.css
+++ b/style.css
@@ -559,7 +559,7 @@ div[name="templatesAndPopupsWrapper"] {
     }
 
     .fake-input {
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
         pointer-events: none;


### PR DESCRIPTION
## Changes
- Optimized the amount of data save calls.
> Now that group chats are saved like single chats, storing metadata inside the chat file itself and leading to a browser freeze for long chats, optimizations were made to prevent spamming chat save with every action of the extension. Among them, you can now disable autosaves, preventing this extension from triggering a data save, and allowing you to save data manually. Save buttons were added in the right panel and in the chat status blocks, they will become red when there's unsaved data.
- Fixed a bug where renaming your character would make it loose its status block.
- Added the capability to export/import an status entry from your clipboard.
- You can now refresh the status block for a character in chat.
> Only useful to refresh the value of SillyTavern macros.
- Fixed a bug where having a comment inside a `{{text}}` macro would break the input display in the chat.
- The status popup menu is now wider for PC.
- The layout for `range` inputs changed, making it blend more naturally in the UI.
> The previous layout occupied too much space vertically and it looked off in the rest of the status block, the new layout aims to make it look more natural, and it adds support for using the mouse wheel.
- Updated the layout for `text` and `number` inputs.
> The icon that was at the left of the button, used to focus the input when it is empty, was removed. Now, when the input is empty, a placeholder will be displayed, letting you now it is empty, and allowing you to click on the button with no issues. The placeholder is not sent in the prompt.
- Several bugs were fixed.

## Commits
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/22f3012a6f53d58d1217682e7cbcc867b2b3e7a5) - Set roadmap for rewriting this extension
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/856794341e51866734e52754eab1259b1a56ecf5) - Small code fixes
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/e9610ee228624618fc370be1b6b6dbc9649c6f92) - Optimize popup creation
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/3e25a31535ea75a79f498e3df219cb5988d25dd5) - Get rid of redundant save metadata debounce
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/e8984d8375933a717e7843d5cb19e2025f5fd25b) - Stop relying on form submits to save metadata on popups
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/2e1c8b555dc8af3a4d76e337a800a65e675c174c) - Prevent spamming saveMetadata
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/9020b8ee5b49f3e614f16eb60271891ff219e8cb) - Typo
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/93b0b43ab68c69648376a7031e1624aa84a01a9b) - rename popupDeleteConfirm to popupConfirmAction
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/3a4317aefb21f1965e05fe2ae95182d47e9fd6b9) - Reduced amount of saveChat calls and added manual update mode
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/f9e85c32fdca9b2387b3713e8c4a88b356160c68) - Allow to import a status from clipboard metadata
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/254dc5a93a7a2be350dfeaa719fd6d304077580c) - Prevent importing wrong metadata formats
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/06a5b070743beb8122df330ac0dbf537b3513a68) - Prevent data loss from character rename
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/412fb16e7c105b7255def8cef7fccd91251efc19) - Give visual ques when there is unsaved changes
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/8708bb0dee290c32d917298fdae861fe0c78cf64) - Set autosave-off flags for the rest of the files
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/a2abeea7205cf64f0f252821eea88bce7cc23de5) - Add more saveChat triggers for autosave on
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/b65bd6cf9df332ca720f0fe520fd395624fd938e) - Allow to refresh chat status block
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/e7f3005f367e559d7ca4aaaadccc74e6b07ee075) - Set modified flag on toggle button state change
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/9ef0e17b5702534cb03618b80241a9cb236e6903) - Do not break macros with comments inside
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/61674286ba12af9c2eb1979c000b3cb13c0dd29e) - Prevent incompatibility between comments and macros
- [Styles](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/a134328bc752a95bbd32158db43514061a1423b0) - Make status popup wider for PC
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/c2a0cc46c4fe0ea70c84021be58737de7440feea) - Save changes made in the header of the status menu of a popup
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/0539f32dd3d4b8adfcfb3665bcb35b34d85836f0) - Save header inputs for single char popups too
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/992457c89bbb982e204771c709bf57b0d00278dd)  - Prevent fake inputs from scrolling page all the way up
- [Feat](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/880a12f298502831c8504fa82566e496b1c80a4f) - Allow to add libraries
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/d5e8b4acd54f3ed192c708f225238158f77c8f14) - Change layout for chat input ranges
- [Styles](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/9e098382d8781f651592bab63bf881f0c784042e) - Increase height for chat input range
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/7c4e62b59849997086ea4c52f5795a5dd4095dd4) - Save value of chat range inputs
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/b596b28032b546458bbf5da90201313c45615a8e) - Simplify layout of in-chat range buttons
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/a33f276677d6c249a28dc56ce29af9c17ccb5009) - Added arrows for the new chat range input
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/18efb053593b7e96d14d2f8ed30cae92bcdc491f) - Update status entry value on import from clipboard
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/a37eff6f9f12d7abb764bc76a730e9b059cab632) - Prevent allowing to change chat input on disabled entries
- [Update](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/5c0fee1849d4fa0c6b508b3a0e0ab24c985cca29) - Add placeholder for empty chat text inputs
- [Fix](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/fd2f03e1f3263780507dfff868ae99096ce311b8) - Initialize empty number inputs with zero in chat
- [Update manifest.json](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/f192581a0aa0f27b03c5ae1cfa0c1a2a02704ce3)
- [Update README.md](https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus/pull/42/commits/d482e300a4f107d77704953e10307c264ae9b15f)