### PR TITLE
Fixes and QoL changes to the popup UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "css": "style.css",
     "author": "Leandro Jofre",
     "minimum_client_version": "1.17.0",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "homePage": "https://github.com/leandrojofre/SillyTavern-Stat-us-Maximus.git",
     "auto_update": true
 }

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -517,7 +517,11 @@ async function onShortcutClick(e) {
         return await openSingleStatusPopup(user.avatar, {is_user: true});
     }
 
-    const members = StatUsMaximus.getStatuses();
+    const members = StatUsMaximus.getStatuses().sort((s1, s2) =>
+        (Number(s2.is_detached) - Number(s2.is_user))
+        - (Number(s1.is_detached) - Number(s1.is_user))
+    );
+
     const detachedStatuses = members
         .filter(status => status.is_detached);
 

--- a/source/js/popups.js
+++ b/source/js/popups.js
@@ -329,6 +329,10 @@ async function getStatusPopupBlock(avatar, is_user = false) {
         .text(status.getCharacter().name);
 
     $statusBlock
+            .find(`.${htmlSuffix}-detached-mark`)
+            .toggleClass('d-none', !status.is_detached);
+
+    $statusBlock
         .find(`.${htmlSuffix}-avatar`)
         .attr('src', thumbnail + thumbnailSuffix)
         .attr('title', status.avatar);

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -99,10 +99,18 @@ function getParticipant(charName, isUser, ignoreAvatars = []) {
     if (isUser === 'all') {
         const user = getUser(charName, {searchKey: 'name', ignoreAvatars});
 
-        if (!user)
-            return characters.find(char => char.name === charName && !ignoreAvatars.includes(char.avatar));
+        if (user) return user;
 
-        return user;
+        const character = characters
+            .find(char => char.name === charName && !ignoreAvatars.includes(char.avatar));
+
+        if (character) return character;
+
+        const detached = StatUsMaximus
+            .getStatuses()
+            .find(s => s.name === charName && s.is_detached);
+
+        return detached.getCharacter()
     }
 
     return isUser === 'true' ?
@@ -253,10 +261,11 @@ const ENUMS_STRINGS = {
 
 /**
  * @param {Character|UserCharacter} character
+ * @param {'is_user'|'is_detached'} something
  * @returns {boolean}
  */
-function isCharacterUser(character) {
-    return 'is_user' in character ? character.is_user : false;
+function isCharacterSomething(character, something) {
+    return something in character ? character[something] : false;
 }
 
 /**
@@ -303,7 +312,7 @@ async function commandCreateStatus(args) {
                 ignoreAvatars.push(character.avatar);
 
                 status = StatUsMaximus.addStatus(character.avatar, {
-                    is_user: isCharacterUser(character),
+                    is_user: isCharacterSomething(character, 'is_user'),
                 });
 
                 if (!status) break;
@@ -316,7 +325,7 @@ async function commandCreateStatus(args) {
             if (!character) throw new Error(`The character '${char}' could not be found`);
 
             status = StatUsMaximus.addStatus(character.avatar, {
-                is_user: isCharacterUser(character),
+                is_user: isCharacterSomething(character, 'is_user'),
             });
         }
 

--- a/source/js/slashCommands.js
+++ b/source/js/slashCommands.js
@@ -110,7 +110,7 @@ function getParticipant(charName, isUser, ignoreAvatars = []) {
             .getStatuses()
             .find(s => s.name === charName && s.is_detached);
 
-        return detached.getCharacter()
+        return detached?.getCharacter()
     }
 
     return isUser === 'true' ?

--- a/source/templates/popupStatus.html
+++ b/source/templates/popupStatus.html
@@ -1,6 +1,9 @@
 <div class="stat-us-maximus-custom-css stat-us-maximus-popup flex-container flexFlowColumn gap5px bordered-box">
     <div class="flex-container flex-column flex-center-col gap-5px">
-        <span class="stat-us-maximus-name text-quote"></span>
+        <span class="text-quote">
+            <i class="fa-solid fa-user-slash stat-us-maximus-detached-mark d-none"></i>
+            <span class="stat-us-maximus-name"></span>
+        </span>
 
         <div class="flex-container flex-center-row w-100">
             <form enctype="multipart/form-data">


### PR DESCRIPTION
## Changes
- Slash commands will now properly detect Detached Status blocks
- The popup will now sort blocks in the next order: Detached > Character > User
> User was chosen last because it already has its own popup menu to see only all users.
- Detached blocks inside popups will show an indicator along with their names
> A small visual clue to differentiate them from character blocks.